### PR TITLE
puck: spawn-from-cursor animation, smaller cute size, matte-black + pastel-neon palette

### DIFF
--- a/src/dock_widget.py
+++ b/src/dock_widget.py
@@ -22,46 +22,52 @@ from PyQt6.QtWidgets import QPushButton, QWidget, QLabel
 
 
 # Visual constants
-ICON_SIZE       = 56
+ICON_SIZE       = 44
 COLLAPSED_W     = ICON_SIZE
 COLLAPSED_H     = ICON_SIZE
 PANEL_W         = 280
 EXPANDED_W      = COLLAPSED_W + PANEL_W
 EXPANDED_H      = ICON_SIZE
-RADIUS          = 14
+RADIUS          = 12
 EDGE_MARGIN     = 16
 TOP_MARGIN      = 80
 GAP             = 12
+# Cursor + pip glyphs were originally tuned for a 56px puck; scale them so
+# they stay proportionate when ICON_SIZE changes.
+_PUCK_SCALE     = ICON_SIZE / 56.0
 
-# Palette — deep dark, neon accents
-BG          = QColor(10,  12,  18, 235)
-BG_PANEL    = QColor(14,  16,  24, 240)
-EDGE        = QColor(255, 255, 255,  22)
+# Palette — matte black with pastel-neon accents.
+# Warm-leaning near-black at high opacity reads as smooth velvet rather
+# than the cold blue-tinted dark of the previous palette.
+BG          = QColor(14,  14,  16, 246)
+BG_PANEL    = QColor(18,  18,  22, 248)
+EDGE        = QColor(255, 255, 255,  18)
+INNER_HI    = QColor(255, 255, 255,  12)   # 1px velvet highlight along top inside
 
 TEXT        = QColor(232, 234, 240)
 TEXT_DIM    = QColor(140, 148, 168)
 
-# State accents (used for the pip and for non-running states; running state
-# uses the per-task accent passed into the puck).
-NEON_OK     = QColor( 57, 255,  20)
-NEON_ERR    = QColor(255,  56, 100)
-NEON_PAUS   = QColor(255, 176,  32)
-NEON_AMD    = QColor(255,  72, 220)
+# State accents — pastel-neon (Tailwind 300-tone family). Glow softly against
+# matte black without the saturated "Vegas sign" look.
+NEON_OK     = QColor(134, 239, 172)        # green-300
+NEON_ERR    = QColor(252, 165, 165)        # red-300
+NEON_PAUS   = QColor(252, 211,  77)        # amber-300
+NEON_AMD    = QColor(240, 171, 252)        # fuchsia-300
 
-# Done-state pip color (design reference; paintEvent uses NEON_OK which matches).
-PUCK_PIP_DONE_COLOR = QColor(107, 203, 119)
+# Done-state pip color (kept as alias for callers; same hue as NEON_OK).
+PUCK_PIP_DONE_COLOR = NEON_OK
 
 # Per-task palette — pucks rotate through these so two parallel tasks don't
-# look identical at a glance.
+# look identical at a glance. All pastel-neon tones.
 TASK_PALETTE = [
-    QColor(  0, 217, 255),   # cyan
-    QColor(167, 139, 250),   # violet
-    QColor(255, 138,  76),   # orange
-    QColor( 94, 234, 212),   # teal
-    QColor(248, 113, 113),   # coral
-    QColor(250, 204,  21),   # amber-yellow
-    QColor( 96, 165, 250),   # sky-blue
-    QColor(232, 121, 249),   # fuchsia
+    QColor(125, 211, 252),   # sky-300
+    QColor(196, 181, 253),   # violet-300
+    QColor(253, 186, 116),   # orange-300
+    QColor(110, 231, 183),   # emerald-300
+    QColor(252, 165, 165),   # red-300
+    QColor(252, 211,  77),   # amber-300
+    QColor(147, 197, 253),   # blue-300
+    QColor(240, 171, 252),   # fuchsia-300
 ]
 
 
@@ -403,6 +409,13 @@ class DockedTaskPuck(QWidget):
         p.fillPath(icon_path, BG)
         p.setPen(QPen(EDGE, 1))
         p.drawPath(icon_path)
+        # Velvet highlight along the top inside edge — sells the matte-black feel.
+        hi_rect = QRectF(icon_x + 1, 1, ICON_SIZE - 2, ICON_SIZE - 2)
+        hi_path = QPainterPath()
+        hi_path.addRoundedRect(hi_rect, RADIUS - 1, RADIUS - 1)
+        p.setPen(QPen(INNER_HI, 1))
+        p.setBrush(Qt.BrushStyle.NoBrush)
+        p.drawPath(hi_path)
 
         cursor_color = self._cursor_accent()
         self._paint_glow(p, icon_x + ICON_SIZE / 2, ICON_SIZE / 2, cursor_color)
@@ -460,8 +473,11 @@ class DockedTaskPuck(QWidget):
         path.closeSubpath()
 
         p.save()
-        # Center: cursor's bbox is roughly 16x26 — translate so center is at (cx, cy)
-        p.translate(cx - 8.0, cy - 13.0)
+        # Center: cursor's bbox is roughly 16x26 — translate so center is at (cx, cy).
+        # Scale the glyph proportionate to the puck so it stays cute at smaller sizes.
+        p.translate(cx, cy)
+        p.scale(_PUCK_SCALE, _PUCK_SCALE)
+        p.translate(-8.0, -13.0)
 
         # Body gradient: bright neon at top → slightly darker at bottom
         grad = QLinearGradient(0, 0, 0, 26)
@@ -491,59 +507,62 @@ class DockedTaskPuck(QWidget):
 
     def _paint_state_pip(self, p: QPainter, icon_x: float, _y: float):
         """Pip in the bottom-right corner. Distinct rendering per state so the
-        user can read progress at a glance without hovering."""
-        cx = icon_x + ICON_SIZE - 11
-        cy = ICON_SIZE - 11
+        user can read progress at a glance without hovering. All dimensions
+        scale with _PUCK_SCALE so the pip stays well-proportioned at any
+        puck size."""
+        s = _PUCK_SCALE
+        cx = icon_x + ICON_SIZE - 11 * s
+        cy = ICON_SIZE - 11 * s
         elapsed = time.time() - self._t0
 
         if self._state == "running":
             # Spinning arc — clearly "in progress"
             p.setBrush(QColor(0, 0, 0, 140)); p.setPen(Qt.PenStyle.NoPen)
-            p.drawEllipse(QPointF(cx, cy), 6, 6)
-            p.setBrush(QColor(255, 255, 255, 35)); p.drawEllipse(QPointF(cx, cy), 5.2, 5.2)
+            p.drawEllipse(QPointF(cx, cy), 6 * s, 6 * s)
+            p.setBrush(QColor(255, 255, 255, 35)); p.drawEllipse(QPointF(cx, cy), 5.2 * s, 5.2 * s)
             ang = (elapsed * 360 * 1.0) % 360
-            pen = QPen(self._accent, 1.8)
+            pen = QPen(self._accent, 1.8 * s)
             pen.setCapStyle(Qt.PenCapStyle.RoundCap)
             p.setPen(pen); p.setBrush(Qt.BrushStyle.NoBrush)
-            arc_rect = QRectF(cx - 5.2, cy - 5.2, 10.4, 10.4)
+            arc_rect = QRectF(cx - 5.2 * s, cy - 5.2 * s, 10.4 * s, 10.4 * s)
             p.drawArc(arc_rect, int(-ang * 16), int(120 * 16))
         elif self._state == "paused":
             p.setBrush(QColor(0, 0, 0, 140)); p.setPen(Qt.PenStyle.NoPen)
-            p.drawEllipse(QPointF(cx, cy), 6, 6)
+            p.drawEllipse(QPointF(cx, cy), 6 * s, 6 * s)
             # Two thin vertical bars — pause glyph
             p.setBrush(NEON_PAUS)
-            p.drawRoundedRect(QRectF(cx - 3.4, cy - 3.6, 1.8, 7.2), 0.9, 0.9)
-            p.drawRoundedRect(QRectF(cx + 1.6, cy - 3.6, 1.8, 7.2), 0.9, 0.9)
+            p.drawRoundedRect(QRectF(cx - 3.4 * s, cy - 3.6 * s, 1.8 * s, 7.2 * s), 0.9 * s, 0.9 * s)
+            p.drawRoundedRect(QRectF(cx + 1.6 * s, cy - 3.6 * s, 1.8 * s, 7.2 * s), 0.9 * s, 0.9 * s)
         elif self._state == "done":
             # Solid bright dot with a subtle outer halo — "complete"
-            halo = QRadialGradient(QPointF(cx, cy), 9)
+            halo = QRadialGradient(QPointF(cx, cy), 9 * s)
             c0 = QColor(NEON_OK); c0.setAlpha(110)
             c1 = QColor(NEON_OK); c1.setAlpha(0)
             halo.setColorAt(0, c0); halo.setColorAt(1, c1)
             p.setBrush(QBrush(halo)); p.setPen(Qt.PenStyle.NoPen)
-            p.drawEllipse(QPointF(cx, cy), 9, 9)
+            p.drawEllipse(QPointF(cx, cy), 9 * s, 9 * s)
             p.setBrush(QColor(0, 0, 0, 160))
-            p.drawEllipse(QPointF(cx, cy), 6, 6)
+            p.drawEllipse(QPointF(cx, cy), 6 * s, 6 * s)
             p.setBrush(NEON_OK)
-            p.drawEllipse(QPointF(cx, cy), 4.0, 4.0)
+            p.drawEllipse(QPointF(cx, cy), 4.0 * s, 4.0 * s)
             # Tiny check tick
-            pen = QPen(QColor(10, 14, 18, 220), 1.4)
+            pen = QPen(QColor(10, 14, 18, 220), 1.4 * s)
             pen.setCapStyle(Qt.PenCapStyle.RoundCap)
             p.setPen(pen)
-            p.drawLine(QPointF(cx - 2.2, cy + 0.1),
-                       QPointF(cx - 0.6, cy + 1.7))
-            p.drawLine(QPointF(cx - 0.6, cy + 1.7),
-                       QPointF(cx + 2.4, cy - 1.6))
+            p.drawLine(QPointF(cx - 2.2 * s, cy + 0.1 * s),
+                       QPointF(cx - 0.6 * s, cy + 1.7 * s))
+            p.drawLine(QPointF(cx - 0.6 * s, cy + 1.7 * s),
+                       QPointF(cx + 2.4 * s, cy - 1.6 * s))
         elif self._state in ("error", "cancelled"):
             p.setBrush(QColor(0, 0, 0, 160)); p.setPen(Qt.PenStyle.NoPen)
-            p.drawEllipse(QPointF(cx, cy), 6, 6)
+            p.drawEllipse(QPointF(cx, cy), 6 * s, 6 * s)
             p.setBrush(NEON_ERR)
-            p.drawEllipse(QPointF(cx, cy), 4.0, 4.0)
-            pen = QPen(QColor(10, 14, 18, 220), 1.4)
+            p.drawEllipse(QPointF(cx, cy), 4.0 * s, 4.0 * s)
+            pen = QPen(QColor(10, 14, 18, 220), 1.4 * s)
             pen.setCapStyle(Qt.PenCapStyle.RoundCap)
             p.setPen(pen)
-            p.drawLine(QPointF(cx - 1.8, cy - 1.8), QPointF(cx + 1.8, cy + 1.8))
-            p.drawLine(QPointF(cx - 1.8, cy + 1.8), QPointF(cx + 1.8, cy - 1.8))
+            p.drawLine(QPointF(cx - 1.8 * s, cy - 1.8 * s), QPointF(cx + 1.8 * s, cy + 1.8 * s))
+            p.drawLine(QPointF(cx - 1.8 * s, cy + 1.8 * s), QPointF(cx + 1.8 * s, cy - 1.8 * s))
 
     # ── Utilities ──────────────────────────────────────────────────────────────
 

--- a/src/task_manager.py
+++ b/src/task_manager.py
@@ -6,7 +6,10 @@ re-emits the runner's reader-thread callbacks as Qt signals on the main thread.
 import threading
 from collections.abc import Callable
 
-from PyQt6.QtCore import QObject, QPoint, pyqtSignal
+from PyQt6.QtCore import (
+    QObject, QPoint, QPropertyAnimation, QEasingCurve, QRect, pyqtSignal,
+)
+from PyQt6.QtGui import QCursor
 from PyQt6.QtWidgets import QApplication
 
 from src.agent_runner import AgentRunner
@@ -133,17 +136,59 @@ class TaskManager(QObject):
         task.start_amend = self.task_amend_start.emit
         task.stop_amend  = self.task_amend_stop.emit
         task.finished.connect(self._on_task_finished)
+
+        # Place the puck at the user's cursor before adding to layout, so it
+        # spawns there visually rather than at Qt's default screen-center.
+        cursor = QCursor.pos()
+        task.puck.setGeometry(
+            cursor.x() - COLLAPSED_W // 2,
+            cursor.y() - COLLAPSED_H // 2,
+            COLLAPSED_W, COLLAPSED_H,
+        )
+
         self._tasks.append(task)
-        self._relayout()
         task.puck.show()
-        # Pin the puck so it floats above all apps even when curby isn't
-        # focused — must be called after show() so the NSWindow exists.
         make_always_visible(task.puck)
-        # Respect collapse-all state: hide immediately if user collapsed.
         if self._all_collapsed:
             task.puck.hide()
+            self._relayout()
+            task.start()
+            return task
+
+        # Compute the dock slot for this puck, then animate the puck from the
+        # cursor into that slot. _relayout positions every other puck normally
+        # but skips the animating one so it doesn't snap.
+        target = self._dock_slot_rect(task)
+        self._relayout(skip=task.puck)
+        if target is not None:
+            self._animate_to_dock(task.puck, target)
+
         task.start()
         return task
+
+    def _dock_slot_rect(self, task: Task) -> QRect | None:
+        screen = QApplication.primaryScreen()
+        if screen is None:
+            return None
+        geom = screen.availableGeometry()
+        # Slot index = position among visible pucks (this task is last).
+        idx = sum(
+            1 for t in self._tasks
+            if t is not task and t.puck.isVisible()
+        )
+        x = geom.right() - EDGE_MARGIN - COLLAPSED_W
+        y = geom.top() + TOP_MARGIN + idx * (COLLAPSED_H + GAP)
+        return QRect(x, y, COLLAPSED_W, COLLAPSED_H)
+
+    def _animate_to_dock(self, puck, target: QRect) -> None:
+        anim = QPropertyAnimation(puck, b"geometry", puck)
+        anim.setDuration(320)
+        anim.setStartValue(puck.geometry())
+        anim.setEndValue(target)
+        anim.setEasingCurve(QEasingCurve.Type.OutCubic)
+        anim.finished.connect(lambda: self._relayout())
+        puck._spawn_anim = anim   # keep ref alive
+        anim.start()
 
     def amend(self, task: Task, text: str):
         task.runner.amend(text)
@@ -154,7 +199,7 @@ class TaskManager(QObject):
             self._tasks.remove(task)
         self._relayout()
 
-    def _relayout(self):
+    def _relayout(self, skip=None):
         screen = QApplication.primaryScreen()
         if screen is None:
             return
@@ -163,10 +208,11 @@ class TaskManager(QObject):
         btn_x = right - COLLAPSED_W
 
         # Position only visible pucks (hidden in collapse-all mode are skipped).
+        # `skip` excludes a puck currently mid-animation so we don't fight it.
         visible_idx = 0
         first_visible_y = geom.top() + TOP_MARGIN
         for t in self._tasks:
-            if not t.puck.isVisible():
+            if not t.puck.isVisible() or t.puck is skip:
                 continue
             x = btn_x
             y = geom.top() + TOP_MARGIN + visible_idx * (COLLAPSED_H + GAP)

--- a/tests/test_agentic_flow.py
+++ b/tests/test_agentic_flow.py
@@ -646,7 +646,7 @@ def test_relayout_skips_expanded_pucks():
     _relayout never moves a puck whose panel is currently open.
     """
     from PyQt6.QtWidgets import QApplication
-    from src.dock_widget import COLLAPSED_W, EXPANDED_W
+    from src.dock_widget import COLLAPSED_W, COLLAPSED_H, EXPANDED_W
     from src.task_manager import TaskManager
 
     app = QApplication.instance() or QApplication(sys.argv)
@@ -670,15 +670,15 @@ def test_relayout_skips_expanded_pucks():
 
     expanded = _FakeTask(EXPANDED_W)
     collapsed = _FakeTask(COLLAPSED_W)
-    expanded.puck._geom = (123, 456, EXPANDED_W, 56)  # arbitrary current pos
+    expanded.puck._geom = (123, 456, EXPANDED_W, COLLAPSED_H)  # arbitrary current pos
     tm._tasks = [expanded, collapsed]
 
     tm._relayout()
 
     # Expanded puck must be untouched.
-    assert expanded.puck._geom == (123, 456, EXPANDED_W, 56)
+    assert expanded.puck._geom == (123, 456, EXPANDED_W, COLLAPSED_H)
     # Collapsed puck must have been repositioned.
-    assert collapsed.puck._geom != (0, 0, COLLAPSED_W, 56)
+    assert collapsed.puck._geom != (0, 0, COLLAPSED_W, COLLAPSED_H)
 
 
 # ── AgentRunner companion thread (issue-13) ──────────────────────────────────
@@ -815,7 +815,8 @@ def test_check_hover_calls_on_enter_inside_expanded_panel():
 
     # When expanded, panel_global_rect() returns the same full rect as frameGeometry().
     # Use a wider rect to simulate expanded state.
-    rect = QRect(636, 100, 336, 56)  # COLLAPSED_W + PANEL_W wide
+    from src.dock_widget import COLLAPSED_W, COLLAPSED_H, PANEL_W
+    rect = QRect(636, 100, COLLAPSED_W + PANEL_W, COLLAPSED_H)
     task, enters, leaves = _make_hover_task(rect, visible=True, expanded=True)
     tm._tasks = [task]
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -83,10 +83,10 @@ def _fake_cursor_module(monkeypatch, position_ref):
 def _make_puck():
     from PyQt6.QtGui import QColor
     from PyQt6.QtWidgets import QApplication
-    from src.dock_widget import DockedTaskPuck, COLLAPSED_W
+    from src.dock_widget import DockedTaskPuck, COLLAPSED_W, COLLAPSED_H
     app = QApplication.instance() or QApplication(sys.argv)
     puck = DockedTaskPuck("hover-test", QColor(0, 217, 255))
-    puck.setGeometry(1000, 100, COLLAPSED_W, 56)
+    puck.setGeometry(1000, 100, COLLAPSED_W, COLLAPSED_H)
     puck.show()
     return app, puck
 


### PR DESCRIPTION
## Summary
- Pucks now spawn at the user's cursor and **animate** (320ms OutCubic) into their dock slot at top-right. Fixes the bug where new pucks briefly appeared at screen-center before any layout trigger.
- `ICON_SIZE` 56 → **44** ("cute sized"). Cursor glyph and state pip scale proportionally via a new `_PUCK_SCALE` constant so detail stays clean.
- Palette swap to **matte-black + pastel-neon**:
  - BG warmer near-black `(14,14,16)` at higher opacity for the velvet feel; subtle 1px inner highlight along the top edge.
  - State accents + `TASK_PALETTE` moved to Tailwind 300-tone pastel-neons (sky / violet / orange / emerald / red / amber / blue / fuchsia). Glows nicely without the saturated Vegas-sign look.

## Test plan
- [x] `pytest tests/test_agentic_flow.py tests/test_integration.py` — 66 passed, 2 skipped
- [ ] **Manual UI sanity**: spawn a task, verify puck animates from cursor → top-right dock slot
- [ ] **Manual UI sanity**: confirm matte black reads smooth and pastel-neon accents look right against it
- [ ] **Manual UI sanity**: confirm running spinner pip + done check tick still render crisply at the smaller pip size

🤖 Generated with [Claude Code](https://claude.com/claude-code)