### PR TITLE
feat(ui): cooler cursor orb + persistent thinking indicator

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,7 +20,7 @@ from src.mac_window import make_always_visible
 from src.ptt_listener import PTTListener
 from src.task_manager import TaskManager, Task
 from src.text_input_popup import TextInputPopup
-from src.voice_indicator import VoiceIndicator
+from src.buddy_icon import BuddyIcon
 
 HOTKEY_TYPE = "<ctrl>+."     # alternate input: type the prompt instead of speaking
 HOTKEY_QUICK = "<ctrl>+<space>"      # quick-ask: voice in → short Claude answer → voice out (PRIMARY)
@@ -43,6 +43,7 @@ class _Bridge(QObject):
     type_hotkey_fired   = pyqtSignal()
     quick_hotkey_fired  = pyqtSignal()
     quit_hotkey_fired   = pyqtSignal()
+    voice_state_change  = pyqtSignal(str)  # marshaled from worker threads to flip the indicator
 
 
 class CurbyApp:
@@ -50,7 +51,7 @@ class CurbyApp:
         self._qt = QApplication.instance() or QApplication(sys.argv)
         self._bridge = _Bridge()
 
-        self._voice = VoiceIndicator()
+        self._voice = BuddyIcon()
         self._tasks = TaskManager()
         self._tasks.task_amend_start.connect(self._on_amend_start)
         self._tasks.task_amend_stop.connect(self._on_amend_stop)
@@ -101,6 +102,7 @@ class CurbyApp:
         self._bridge.type_hotkey_fired.connect(self._on_type_hotkey)
         self._bridge.quick_hotkey_fired.connect(self._on_quick_hotkey)
         self._bridge.quit_hotkey_fired.connect(self._quit)
+        self._bridge.voice_state_change.connect(self._voice.set_state)
 
     # ── Cursor follow ─────────────────────────────────────────────────────────
 
@@ -203,14 +205,18 @@ class CurbyApp:
     # ── Transcription results ─────────────────────────────────────────────────
 
     def _on_transcription(self, text: str, target):
-        self._voice.set_state("idle")
         print(f"[heard] {text!r}")
         if isinstance(target, Task):
+            self._voice.set_state("idle")
             print(f"[amend] queueing on {target.prompt[:40]!r}")
             self._tasks.amend(target, text)
         elif target == QUICK_ASK_TARGET:
+            # Keep the indicator alive in a "thinking" pulse until the reply
+            # lands — the worker thread flips it through speaking → idle.
+            self._voice.set_state("thinking")
             self._run_quick_ask(text)
         else:
+            self._voice.set_state("idle")
             try:
                 t = self._tasks.spawn(text)
                 print(f"[spawn] task in {t.runner.workdir}")
@@ -218,8 +224,13 @@ class CurbyApp:
                 print(f"[spawn] failed: {e}")
 
     def _run_quick_ask(self, prompt: str):
-        """Run the quick-ask in a background thread so the Qt loop stays responsive."""
+        """Run the quick-ask in a background thread so the Qt loop stays responsive.
+
+        The indicator state is driven via bridge signals (Qt-thread-safe):
+        thinking (already set by caller) → speaking (just before TTS) → idle.
+        """
         worker = self._claude_worker
+        bridge = self._bridge
         def _work():
             from src.quick_ask import run_quick_ask, log_quick_ask, speak_reply
             try:
@@ -227,13 +238,17 @@ class CurbyApp:
             except Exception as e:
                 msg = f"quick-ask failed: {e}"
                 print(f"[quick-ask] {msg}", flush=True)
+                bridge.voice_state_change.emit("error")
                 try: speak_reply("sorry, something went wrong.")
                 except Exception: pass
+                bridge.voice_state_change.emit("idle")
                 return
             tag = "follow-up" if was_followup else "new"
             print(f"[quick-ask] {tag} reply ({latency_ms} ms): {reply!r}", flush=True)
             log_quick_ask(prompt, reply, latency_ms, was_followup=was_followup)
-            speak_reply(reply)
+            bridge.voice_state_change.emit("speaking")
+            speak_reply(reply)  # blocks until TTS completes (subprocess wait)
+            bridge.voice_state_change.emit("idle")
         threading.Thread(target=_work, daemon=True).start()
 
     def _on_transcription_error(self, msg: str):

--- a/src/buddy_icon.py
+++ b/src/buddy_icon.py
@@ -34,10 +34,12 @@ class BuddyIcon(QWidget):
     def __init__(self):
         super().__init__()
         self._state = "idle"
+        self._level = 0.0           # latest mic input level (0..1), used in listening state
+        self._smoothed_level = 0.0
         self._t0 = time.time()
         self._setup()
         self._timer = QTimer(self)
-        self._timer.timeout.connect(self.update)
+        self._timer.timeout.connect(self._on_tick)
         self._timer.start(16)
 
     def _setup(self):
@@ -55,7 +57,26 @@ class BuddyIcon(QWidget):
     def set_state(self, state: str):
         if state != self._state:
             self._state = state
+            if state != "listening":
+                self._level = 0.0
             self.update()
+
+    def set_level(self, level_0_to_1: float):
+        """Latest mic input level, normalized to 0..1. Drives orb-scale pulse
+        while in the listening state."""
+        self._level = max(0.0, min(1.0, level_0_to_1))
+
+    def _on_tick(self):
+        # Exponential smoothing of the mic level so the pulse feels organic.
+        self._smoothed_level = 0.78 * self._smoothed_level + 0.22 * self._level
+        self.update()
+
+    # Alias for the existing CurbyApp signal name.
+    def follow(self, cursor_x: int, cursor_y: int):
+        self.move_near_cursor(cursor_x, cursor_y)
+        if not self.isVisible():
+            self.show()
+            self.raise_()
 
     def paintEvent(self, _):
         p = QPainter(self)
@@ -65,10 +86,28 @@ class BuddyIcon(QWidget):
         accent = STATE_ACCENT.get(self._state, STEEL)
         active = self._state in ("thinking", "listening", "speaking")
         elapsed = time.time() - self._t0
-        breathe = (math.sin(elapsed * (4.0 if active else 1.6)) + 1) * 0.5
+
+        # Pulse rate depends on state. Thinking is a faster, more anxious-looking
+        # pulse so you can tell something's still happening even when nothing
+        # is audible. Listening is mic-level-driven.
+        if self._state == "thinking":
+            breathe = (math.sin(elapsed * 6.5) + 1) * 0.5
+        elif self._state == "speaking":
+            breathe = (math.sin(elapsed * 5.0) + 1) * 0.5
+        elif active:
+            breathe = (math.sin(elapsed * 4.0) + 1) * 0.5
+        else:
+            breathe = (math.sin(elapsed * 1.6) + 1) * 0.5
+
+        # In listening state, the orb pulses with the mic input level so the
+        # user gets the "I hear you" feedback the bars used to provide.
+        orb_scale = 1.0
+        if self._state == "listening":
+            orb_scale = 1.0 + 0.18 * self._smoothed_level
 
         # Outer halo (soft radial)
-        halo = QRadialGradient(cx, cy, HALO + SIZE / 2)
+        halo_radius = (HALO + SIZE / 2) * orb_scale
+        halo = QRadialGradient(cx, cy, halo_radius)
         a0 = QColor(accent); a0.setAlpha(int((80 if active else 40) + 80 * breathe))
         a1 = QColor(accent); a1.setAlpha(int((40 if active else 20) + 30 * breathe))
         a2 = QColor(accent); a2.setAlpha(0)
@@ -77,10 +116,11 @@ class BuddyIcon(QWidget):
         halo.setColorAt(1.0, a2)
         p.setBrush(halo)
         p.setPen(Qt.PenStyle.NoPen)
-        p.drawEllipse(QPointF(cx, cy), HALO + SIZE / 2, HALO + SIZE / 2)
+        p.drawEllipse(QPointF(cx, cy), halo_radius, halo_radius)
 
         # Orb gradient fill (top-light to accent)
-        orb = QRadialGradient(cx - SIZE * 0.18, cy - SIZE * 0.2, SIZE * 0.9)
+        orb_radius = (SIZE / 2) * orb_scale
+        orb = QRadialGradient(cx - SIZE * 0.18, cy - SIZE * 0.2, SIZE * 0.9 * orb_scale)
         hi = QColor(255, 255, 255); hi.setAlpha(230)
         mid = QColor(accent); mid.setAlpha(240)
         base = QColor(accent); base.setAlpha(255)
@@ -88,13 +128,13 @@ class BuddyIcon(QWidget):
         orb.setColorAt(0.35, mid)
         orb.setColorAt(1.0, base)
         p.setBrush(orb)
-        p.drawEllipse(QPointF(cx, cy), SIZE / 2, SIZE / 2)
+        p.drawEllipse(QPointF(cx, cy), orb_radius, orb_radius)
 
         # Thin inner rim (white @ low alpha)
         rim = QColor(255, 255, 255, 80)
         p.setPen(rim)
         p.setBrush(Qt.BrushStyle.NoBrush)
-        p.drawEllipse(QPointF(cx, cy), SIZE / 2 - 0.5, SIZE / 2 - 0.5)
+        p.drawEllipse(QPointF(cx, cy), orb_radius - 0.5, orb_radius - 0.5)
 
     def move_near_cursor(self, x: int, y: int):
         self.move(x + OFFSET_X, y + OFFSET_Y)


### PR DESCRIPTION
## Summary

- Swap the cursor-following indicator from the bars-on-a-pill `VoiceIndicator` to the orb-style `BuddyIcon` (already in the tree, just unused). Halo, gradient, breathing pulse, per-state accent colors.
- Fix indicator-going-idle-too-early bug: the indicator now stays in a fast \"thinking\" pulse through the full quick-ask wait, flips to \"speaking\" during TTS, and only goes idle after speech ends.

## Behavior

- States with colors: idle=steel, listening=pink-hot, thinking=violet (fast pulse), speaking=mint, error=red.
- Orb gently scales with mic input level while listening (preserves the \"I hear you\" feedback the bars provided).
- State transitions during the quick-ask flow are marshaled from the background worker thread via a new \`voice_state_change\` bridge signal — Qt-thread-safe.

## Test plan

- [x] Full suite: 80 passed, 2 skipped, 1 pre-existing flake unrelated to this change.
- [ ] **Manual end-to-end**: tap \`Ctrl+Space\`, ask anything → expect the orb to stay pulsing violet through the entire wait, flip mint when TTS starts, go steel-grey when speech ends. No moment where the orb looks idle while something is still happening.

## Related

- #20 (persistent worker is slower than one-shot) — separate perf issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)