### PR TITLE
feat: floating answer note + ghost-cursor revival

### DIFF
--- a/src/answer_note.py
+++ b/src/answer_note.py
@@ -1,0 +1,238 @@
+"""Floating answer note — a small draggable panel that shows the latest
+quick-ask reply as readable text.
+
+Lives top-right of the primary screen by default; the user can drag it
+anywhere and click to toggle between a full panel and a tiny dot. The
+position survives drags but resets to top-right on each curby start
+(intentional — keeps the screen tidy).
+
+Visual identity is a soft blue rounded panel (vs claude-meter's green
+ring), translucent dark background, single block of reply text. When
+collapsed, just a small blue dot.
+
+Pattern mirrors claude-meter/src/claude_meter/window.py:
+- frameless top-level window, stays on top, click-through-able when idle
+- mousePress→Move→Release with a small px threshold to distinguish
+  click (toggle collapse) from drag (move the widget)
+"""
+from PyQt6.QtCore import Qt, QPoint, QRectF, QTimer
+from PyQt6.QtGui import QPainter, QColor, QPen, QPainterPath, QFont, QFontMetrics
+from PyQt6.QtWidgets import QWidget, QApplication
+
+
+# ── Visual constants ─────────────────────────────────────────────────────────
+
+PANEL_W              = 340
+PANEL_MIN_H          = 80
+PANEL_MAX_H          = 260
+PANEL_PADDING        = 16
+PANEL_RADIUS         = 14
+
+DOT_SIZE             = 22
+EDGE_MARGIN          = 18
+DRAG_THRESHOLD_PX    = 4
+
+# Palette — soft electric blue accent on a deep matte background.
+BG                   = QColor(14,  16,  26, 246)
+BG_BORDER            = QColor(96, 165, 250,  80)   # blue-400 @ low alpha
+ACCENT               = QColor(96, 165, 250, 255)   # blue-400
+ACCENT_DIM           = QColor(96, 165, 250, 140)
+TEXT                 = QColor(232, 234, 245)
+TEXT_DIM             = QColor(140, 148, 168)
+LABEL                = QColor(96, 165, 250, 200)
+
+
+class AnswerNote(QWidget):
+    """Floating panel showing the latest quick-ask reply."""
+
+    def __init__(self):
+        super().__init__()
+        self.setWindowFlags(
+            Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.Tool
+            | Qt.WindowType.WindowDoesNotAcceptFocus
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+
+        self._text = ""
+        self._latency_ms: int | None = None
+        self._collapsed = False
+        # Drag state — None means not dragging.
+        self._drag_origin: QPoint | None = None
+        self._drag_moved = False
+
+        # The text font drives height computation. Use the system UI font at
+        # a comfortable readable size, not Qt's tiny default.
+        self._font = QFont()
+        self._font.setPointSize(13)
+        self._font.setStyleStrategy(QFont.StyleStrategy.PreferAntialias)
+        self._label_font = QFont()
+        self._label_font.setPointSize(9)
+        self._label_font.setBold(True)
+        self._label_font.setLetterSpacing(QFont.SpacingType.AbsoluteSpacing, 1.2)
+
+        self.resize(PANEL_W, PANEL_MIN_H)
+        self._position_top_right()
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def set_reply(self, text: str, latency_ms: int | None = None) -> None:
+        """Replace the visible reply. Expands the panel if it was collapsed
+        so the user sees the new answer arrive."""
+        self._text = (text or "").strip()
+        self._latency_ms = latency_ms
+        if self._collapsed:
+            self._set_collapsed(False, keep_position=True)
+        self._resize_to_fit()
+        self.update()
+        if not self.isVisible():
+            self.show()
+            self.raise_()
+
+    def show_initial(self) -> None:
+        """Called once at app start so the panel is visible from the get-go."""
+        self._text = ""
+        self._resize_to_fit()
+        self.show()
+        self.raise_()
+
+    # ── Layout ─────────────────────────────────────────────────────────────────
+
+    def _position_top_right(self) -> None:
+        screen = QApplication.primaryScreen()
+        if screen is None:
+            return
+        geo = screen.availableGeometry()
+        x = geo.right() - PANEL_W - EDGE_MARGIN
+        y = geo.top() + EDGE_MARGIN
+        self.move(x, y)
+
+    def _resize_to_fit(self) -> None:
+        if self._collapsed:
+            self.setFixedSize(DOT_SIZE, DOT_SIZE)
+            return
+        # Compute the height needed to display the current text, clamped
+        # between PANEL_MIN_H and PANEL_MAX_H.
+        fm = QFontMetrics(self._font)
+        usable_w = PANEL_W - 2 * PANEL_PADDING
+        if not self._text:
+            text_h = fm.height()
+        else:
+            rect = fm.boundingRect(
+                0, 0, usable_w, 10_000,
+                Qt.TextFlag.TextWordWrap, self._text,
+            )
+            text_h = rect.height()
+        label_h = QFontMetrics(self._label_font).height() + 8
+        h = max(PANEL_MIN_H, min(PANEL_MAX_H, text_h + label_h + 2 * PANEL_PADDING))
+        self.setFixedSize(PANEL_W, h)
+
+    def _set_collapsed(self, collapsed: bool, *, keep_position: bool = False) -> None:
+        if collapsed == self._collapsed:
+            return
+        was_topleft = self.pos()
+        self._collapsed = collapsed
+        if collapsed:
+            self.setFixedSize(DOT_SIZE, DOT_SIZE)
+        else:
+            self._resize_to_fit()
+        if not keep_position:
+            self.move(was_topleft)
+        self.update()
+
+    # ── Mouse: drag-to-move + click-to-toggle ─────────────────────────────────
+
+    def mousePressEvent(self, event):  # noqa: N802
+        if event.button() != Qt.MouseButton.LeftButton:
+            return
+        self._drag_origin = event.globalPosition().toPoint() - self.frameGeometry().topLeft()
+        self._drag_moved = False
+        event.accept()
+
+    def mouseMoveEvent(self, event):  # noqa: N802
+        if self._drag_origin is None or not (event.buttons() & Qt.MouseButton.LeftButton):
+            return
+        new_global = event.globalPosition().toPoint()
+        new_pos = new_global - self._drag_origin
+        if not self._drag_moved:
+            delta = (new_pos - self.pos()).manhattanLength()
+            if delta > DRAG_THRESHOLD_PX:
+                self._drag_moved = True
+        if self._drag_moved:
+            self.move(new_pos)
+        event.accept()
+
+    def mouseReleaseEvent(self, event):  # noqa: N802
+        if event.button() != Qt.MouseButton.LeftButton or self._drag_origin is None:
+            return
+        was_dragged = self._drag_moved
+        self._drag_origin = None
+        self._drag_moved = False
+        if not was_dragged:
+            # Treat as a click → toggle collapse.
+            self._set_collapsed(not self._collapsed, keep_position=True)
+        event.accept()
+
+    # ── Paint ──────────────────────────────────────────────────────────────────
+
+    def paintEvent(self, _):  # noqa: N802
+        p = QPainter(self)
+        p.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        if self._collapsed:
+            self._paint_dot(p)
+        else:
+            self._paint_panel(p)
+
+    def _paint_dot(self, p: QPainter) -> None:
+        rect = QRectF(0, 0, self.width(), self.height()).adjusted(1, 1, -1, -1)
+        path = QPainterPath()
+        path.addEllipse(rect)
+        p.fillPath(path, ACCENT)
+        p.setPen(QPen(BG_BORDER, 1.5))
+        p.setBrush(Qt.BrushStyle.NoBrush)
+        p.drawPath(path)
+
+    def _paint_panel(self, p: QPainter) -> None:
+        rect = QRectF(0, 0, self.width(), self.height()).adjusted(0.5, 0.5, -0.5, -0.5)
+        path = QPainterPath()
+        path.addRoundedRect(rect, PANEL_RADIUS, PANEL_RADIUS)
+        p.fillPath(path, BG)
+        p.setPen(QPen(BG_BORDER, 1))
+        p.setBrush(Qt.BrushStyle.NoBrush)
+        p.drawPath(path)
+
+        # Tiny accent stripe down the left edge — visual hook for "this is the
+        # answer panel" without making it loud.
+        stripe = QRectF(0, PANEL_PADDING, 3, self.height() - 2 * PANEL_PADDING)
+        stripe_path = QPainterPath()
+        stripe_path.addRoundedRect(stripe, 1.5, 1.5)
+        p.fillPath(stripe_path, ACCENT)
+
+        # Header label.
+        p.setFont(self._label_font)
+        p.setPen(QPen(LABEL))
+        label_text = "CURBY"
+        if self._latency_ms is not None:
+            label_text += f"   ·   {self._latency_ms} ms"
+        p.drawText(
+            int(PANEL_PADDING), int(PANEL_PADDING),
+            int(self.width() - 2 * PANEL_PADDING), 20,
+            int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop),
+            label_text,
+        )
+
+        # Body text.
+        p.setFont(self._font)
+        text_color = TEXT if self._text else TEXT_DIM
+        p.setPen(QPen(text_color))
+        body = self._text or "Tap Ctrl+Space to ask Claude anything."
+        body_y = PANEL_PADDING + 22
+        p.drawText(
+            int(PANEL_PADDING), int(body_y),
+            int(self.width() - 2 * PANEL_PADDING), int(self.height() - body_y - PANEL_PADDING),
+            int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop | Qt.TextFlag.TextWordWrap),
+            body,
+        )

--- a/src/app.py
+++ b/src/app.py
@@ -20,7 +20,7 @@ from src.mac_window import make_always_visible
 from src.ptt_listener import PTTListener
 from src.task_manager import TaskManager, Task
 from src.text_input_popup import TextInputPopup
-from src.voice_indicator import VoiceIndicator
+from src.ghost_cursor import GhostCursor
 
 HOTKEY_TYPE = "<ctrl>+."     # alternate input: type the prompt instead of speaking
 HOTKEY_QUICK = "<ctrl>+<space>"      # quick-ask: voice in → short Claude answer → voice out (PRIMARY)
@@ -52,7 +52,7 @@ class CurbyApp:
         self._qt = QApplication.instance() or QApplication(sys.argv)
         self._bridge = _Bridge()
 
-        self._voice = VoiceIndicator()
+        self._voice = GhostCursor()
         self._tasks = TaskManager()
         self._tasks.task_amend_start.connect(self._on_amend_start)
         self._tasks.task_amend_stop.connect(self._on_amend_stop)

--- a/src/app.py
+++ b/src/app.py
@@ -44,6 +44,7 @@ class _Bridge(QObject):
     quick_hotkey_fired  = pyqtSignal()
     quit_hotkey_fired   = pyqtSignal()
     voice_state_change  = pyqtSignal(str)  # marshaled from worker threads to flip the indicator
+    answer_ready        = pyqtSignal(str, int)   # reply text, latency_ms — drives the floating note
 
 
 class CurbyApp:
@@ -64,6 +65,10 @@ class CurbyApp:
         from src.claude_worker import ClaudeWorker
         from src.quick_ask import _SYSTEM as _QUICK_ASK_SYSTEM
         self._claude_worker = ClaudeWorker(system_prompt=_QUICK_ASK_SYSTEM, model="haiku")
+
+        # Floating answer note (top-right, draggable, click-to-collapse).
+        from src.answer_note import AnswerNote
+        self._answer_note = AnswerNote()
 
         self._cx = 0
         self._cy = 0
@@ -103,6 +108,7 @@ class CurbyApp:
         self._bridge.quick_hotkey_fired.connect(self._on_quick_hotkey)
         self._bridge.quit_hotkey_fired.connect(self._quit)
         self._bridge.voice_state_change.connect(self._voice.set_state)
+        self._bridge.answer_ready.connect(self._answer_note.set_reply)
 
     # ── Cursor follow ─────────────────────────────────────────────────────────
 
@@ -246,6 +252,7 @@ class CurbyApp:
             tag = "follow-up" if was_followup else "new"
             print(f"[quick-ask] {tag} reply ({latency_ms} ms): {reply!r}", flush=True)
             log_quick_ask(prompt, reply, latency_ms, was_followup=was_followup)
+            bridge.answer_ready.emit(reply, latency_ms)
             bridge.voice_state_change.emit("speaking")
             speak_reply(reply)  # blocks until TTS completes (subprocess wait)
             bridge.voice_state_change.emit("idle")
@@ -300,6 +307,11 @@ class CurbyApp:
         self._voice.show()
         self._voice.raise_()
         make_always_visible(self._voice)
+
+        # Show the answer note top-right so the user knows it's there
+        # before the first quick-ask.
+        self._answer_note.show_initial()
+        make_always_visible(self._answer_note)
 
         self._cursor.start()
         self._ptt.start()

--- a/src/ghost_cursor.py
+++ b/src/ghost_cursor.py
@@ -53,11 +53,12 @@ LISTEN_PALETTE = [PINK_HOT, FUCHSIA, PINK_SOFT, ROSE]
 #   speaking   mint     — delivering a reply
 #   error      red      — alert
 STATE_PRIMARY = {
-    "idle":      VIOLET,
-    "listening": PINK_HOT,
-    "thinking":  GOLD,
-    "speaking":  MINT,
-    "error":     RED,
+    "idle":       VIOLET,
+    "listening":  PINK_HOT,
+    "processing": GOLD,    # brief transcribe gap — same hue as thinking
+    "thinking":   GOLD,
+    "speaking":   MINT,
+    "error":      RED,
 }
 
 SIZE = 120
@@ -142,6 +143,12 @@ class GhostCursor(QWidget):
     def set_state(self, state: str):
         if state in STATE_PRIMARY and state != self._state:
             self._state = state
+
+    def set_level(self, level_0_to_1: float):
+        """Mic input level — accepted for API compat with VoiceIndicator;
+        GhostCursor's listening visual is driven by its own animation, not
+        the raw level. Kept as a no-op so app.py wiring doesn't crash."""
+        pass
 
     def show_at(self, x: int, y: int):
         self._mode_change_t = time.time()


### PR DESCRIPTION
## Summary

Two coordinated UX upgrades:

1. **Floating answer note** — small blue panel top-right that shows the latest quick-ask reply as readable text. Draggable, click-to-collapse, same pattern as claude-meter.

2. **Ghost-cursor revival** — replace the bars-on-a-pill indicator with the constantly-moving feather/fairy from src/ghost_cursor.py (built but previously retired). Spring-physics following, gentle bob, sparkles, distinct hue per state.

## Behavior

**Floating note:**
- Anchors top-right of primary screen on startup; user drags anywhere; click toggles collapse.
- Header: \"CURBY  ·  NNN ms\" so latency per turn is visible.
- Updates the moment each new reply lands; expands if collapsed.

**Ghost cursor (distinct hue per state):**
| state      | color    | feel                                  |
| ---------- | -------- | ------------------------------------- |
| idle       | violet   | cool, resting, gentle bob             |
| listening  | pink-hot | warm, attentive                       |
| processing | gold     | brief transcribe gap                  |
| thinking   | gold     | claude is generating                  |
| speaking   | mint     | TTS playing                           |
| error      | red      | something went wrong                  |

Fixes \"stays purple even when she's answering\" — distinct hues make the speaking transition obvious.

## Test plan

- [x] Full suite: 81 passed, 2 skipped.
- [ ] **Manual**: floating panel appears top-right on curby start. Drag it; click to collapse; click to expand.
- [ ] **Manual**: Ctrl+Space and watch the feather change hue clearly through pink → gold → mint → violet.

## Related

- #20 (worker perf) — unchanged.
- #16 (TTS voice quality) — next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)