### PR TITLE
feat(voice): premium-voice preference + user config + install hint

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -322,6 +322,19 @@ class CurbyApp:
         # finished initializing yet.
         threading.Thread(target=self._claude_worker.start, daemon=True).start()
 
+        # One-time tip if we don't have a Premium voice installed.
+        try:
+            from src.voice_config import resolve_voice, install_hint
+            voice, _, is_premium = resolve_voice()
+            if not is_premium:
+                picked = voice or "(system default)"
+                print(f"[voice] using {picked}")
+                print(install_hint())
+            else:
+                print(f"[voice] using {voice}")
+        except Exception as e:
+            print(f"[voice] config check failed: {e}")
+
         print("Curby ready.")
         print(f"  Tap Ctrl+Space         — quick-ask: voice question → spoken Claude answer.")
         print(f"  Tap Ctrl+Shift+Space   — spawn an agent task (the old Ctrl+Space).")

--- a/src/quick_ask.py
+++ b/src/quick_ask.py
@@ -144,10 +144,13 @@ def speak_reply(text: str) -> None:
     """
     if platform.system() == "Darwin" and shutil.which("say"):
         try:
-            # -r 220 = 220 words/min. Default is ~175. Faster reads more like
-            # an excited friend talking, less like a calm announcement —
-            # matches the rapid back-and-forth this tool is for.
-            subprocess.run(["say", "-r", "220", text], check=False, timeout=60)
+            from src.voice_config import resolve_voice
+            voice, rate, _ = resolve_voice()
+            cmd = ["say", "-r", str(rate)]
+            if voice:
+                cmd += ["-v", voice]
+            cmd.append(text)
+            subprocess.run(cmd, check=False, timeout=60)
             return
         except Exception as e:
             print(f"[quick-ask] say failed, falling back to pyttsx3: {e}")

--- a/src/voice_config.py
+++ b/src/voice_config.py
@@ -1,0 +1,114 @@
+"""Voice / TTS configuration for quick-ask.
+
+Picks the best macOS `say` voice available, honoring an optional user
+override at ~/.curby/config.json. Defaults to a curated preference list
+that prefers any installed Premium voice (significantly more natural)
+over the basic catalog.
+
+Config file shape:
+    {
+      "voice": "Ava (Premium)",   // exact name as `say -v ?` lists it
+      "rate":  220                 // words per minute
+    }
+
+If `voice` is set, it's used as-is (and unmet preferences are silently
+skipped). If unset, we walk PREFERRED_VOICES and pick the first that
+shows up in `say -v ?`. `rate` defaults to 220.
+"""
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+CONFIG_PATH = Path(os.path.expanduser("~/.curby/config.json"))
+DEFAULT_RATE = 220
+
+# Order matters — first installed match wins. Premium variants are
+# vastly more natural; download via System Settings → Accessibility →
+# Spoken Content → System Voice → Manage Voices.
+PREFERRED_VOICES = [
+    "Ava (Premium)",
+    "Zoe (Premium)",
+    "Allison (Premium)",
+    "Samantha (Premium)",
+    "Evan (Enhanced)",
+    "Ava (Enhanced)",
+    "Samantha (Enhanced)",
+    # Basic-tier fallbacks — installed by default on macOS.
+    "Samantha",
+    "Karen",      # Australian en
+    "Moira",      # Irish en
+    "Tessa",      # South African en
+]
+
+
+def _list_installed_voices() -> list[str]:
+    """Return the bare voice names from `say -v ?` (one per line; the
+    locale + sample sentence are stripped). Empty on any failure — caller
+    just falls back to the system default."""
+    if not shutil.which("say"):
+        return []
+    try:
+        out = subprocess.run(["say", "-v", "?"], capture_output=True,
+                             text=True, timeout=5).stdout
+    except Exception:
+        return []
+    names = []
+    for line in out.splitlines():
+        # Format: "Name (variant)    locale    # Sample sentence."
+        # Drop the trailing locale token + sample so we just have the name.
+        if "#" not in line:
+            continue
+        head = line.split("#", 1)[0].rstrip()
+        parts = head.rsplit(None, 1)
+        if len(parts) != 2:
+            continue
+        full = parts[0].strip()
+        names.append(full)
+        # ALSO include the bare prefix (e.g. "Samantha" alongside
+        # "Samantha (English (US))") so preference-list entries that
+        # don't bake in the locale tag still match. Premium/Enhanced
+        # variants stay as-is — those carry meaning we want to preserve.
+        if " (" in full and "Premium" not in full and "Enhanced" not in full:
+            names.append(full.split(" (", 1)[0])
+    return names
+
+
+def _load_user_config() -> dict:
+    try:
+        return json.loads(CONFIG_PATH.read_text())
+    except Exception:
+        return {}
+
+
+def resolve_voice() -> tuple[str | None, int, bool]:
+    """Returns (voice_name, rate_wpm, used_premium). voice_name is None
+    if no preference matched and we should fall back to `say` default.
+    `used_premium` is True iff the picked voice has '(Premium)' or
+    '(Enhanced)' in its name — used to suppress the install-hint."""
+    cfg = _load_user_config()
+    rate = int(cfg.get("rate", DEFAULT_RATE))
+
+    if cfg.get("voice"):
+        v = str(cfg["voice"])
+        return v, rate, ("Premium" in v or "Enhanced" in v)
+
+    installed = set(_list_installed_voices())
+    for candidate in PREFERRED_VOICES:
+        if candidate in installed:
+            return candidate, rate, ("Premium" in candidate or "Enhanced" in candidate)
+    return None, rate, False
+
+
+def install_hint() -> str:
+    """Multi-line hint to print at startup if we couldn't find a Premium
+    voice. Tells the user how to install one in <2 minutes."""
+    return (
+        "[quick-ask] tip: macOS Premium voices (Ava, Zoe, Allison) sound\n"
+        "  vastly more natural than the default Samantha. Install one via:\n"
+        "  System Settings → Accessibility → Spoken Content → System Voice\n"
+        "  → click the (i), tap a (Premium) voice, download (~100 MB).\n"
+        "  Then either restart curby (it auto-picks) or set the voice name\n"
+        "  in ~/.curby/config.json: {\"voice\": \"Ava (Premium)\"}"
+    )

--- a/tests/test_voice_config.py
+++ b/tests/test_voice_config.py
@@ -1,0 +1,86 @@
+"""Coverage for voice_config — mocks `say -v ?` so tests never depend on
+which voices are actually installed."""
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from src import voice_config
+
+
+# Sample output from `say -v ?` (real macOS format)
+_FAKE_VOICES_BASIC = """\
+Albert              en_US    # Hello! My name is Albert.
+Samantha (English (US)) en_US    # Hello! My name is Samantha.
+Karen               en_AU    # Hello! My name is Karen.
+"""
+
+_FAKE_VOICES_WITH_PREMIUM = """\
+Ava (Premium)       en_US    # Hello! My name is Ava.
+Samantha (English (US)) en_US    # Hello! My name is Samantha.
+Zoe (Premium)       en_US    # Hello! My name is Zoe.
+"""
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(voice_config, "CONFIG_PATH", tmp_path / "config.json")
+    yield
+
+
+def _patch_voices(monkeypatch, raw):
+    def fake_run(cmd, **kw):
+        if cmd[:3] == ["say", "-v", "?"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=raw, stderr="")
+        raise AssertionError("unexpected subprocess call: %r" % cmd)
+    monkeypatch.setattr(voice_config.subprocess, "run", fake_run)
+    monkeypatch.setattr(voice_config.shutil, "which", lambda _: "/usr/bin/say")
+
+
+def test_picks_premium_when_available(monkeypatch):
+    _patch_voices(monkeypatch, _FAKE_VOICES_WITH_PREMIUM)
+    voice, rate, is_premium = voice_config.resolve_voice()
+    assert voice == "Ava (Premium)"
+    assert is_premium is True
+    assert rate == voice_config.DEFAULT_RATE
+
+
+def test_falls_back_to_basic_when_no_premium(monkeypatch):
+    _patch_voices(monkeypatch, _FAKE_VOICES_BASIC)
+    voice, _, is_premium = voice_config.resolve_voice()
+    assert voice == "Samantha"
+    assert is_premium is False
+
+
+def test_user_config_overrides_preference(monkeypatch, tmp_path):
+    _patch_voices(monkeypatch, _FAKE_VOICES_WITH_PREMIUM)
+    (voice_config.CONFIG_PATH).write_text('{"voice": "Karen", "rate": 180}')
+    voice, rate, is_premium = voice_config.resolve_voice()
+    assert voice == "Karen"
+    assert rate == 180
+    assert is_premium is False
+
+
+def test_user_config_premium_marked(monkeypatch, tmp_path):
+    _patch_voices(monkeypatch, _FAKE_VOICES_BASIC)  # premium not installed
+    (voice_config.CONFIG_PATH).write_text('{"voice": "Zoe (Premium)"}')
+    voice, _, is_premium = voice_config.resolve_voice()
+    assert voice == "Zoe (Premium)"
+    assert is_premium is True  # the name says so
+
+
+def test_no_say_returns_none(monkeypatch):
+    monkeypatch.setattr(voice_config.shutil, "which", lambda _: None)
+    voice, _, is_premium = voice_config.resolve_voice()
+    assert voice is None
+    assert is_premium is False
+
+
+def test_corrupt_config_is_ignored(monkeypatch, tmp_path):
+    _patch_voices(monkeypatch, _FAKE_VOICES_WITH_PREMIUM)
+    voice_config.CONFIG_PATH.write_text("{not valid json")
+    voice, _, _ = voice_config.resolve_voice()
+    assert voice == "Ava (Premium)"  # fell through to preferred-list pick


### PR DESCRIPTION
## Summary

Auto-pick the best TTS voice installed, with a user-overridable config and a one-time install hint if no Premium voice is found.

- New \`src/voice_config.py\` — walks a curated preference list (\`Ava (Premium)\` → \`Zoe (Premium)\` → \`Allison (Premium)\` → \`Samantha (Premium)\` → Enhanced → \`Samantha\` fallback). First installed match wins.
- Honors \`~/.curby/config.json\` for explicit voice + rate overrides.
- One-time hint at curby startup if no Premium voice is detected, with step-by-step macOS install instructions.
- 6 new tests; 86 passed total.

## Behavior

User config (optional, at \`~/.curby/config.json\`):
\`\`\`json
{\"voice\": \"Ava (Premium)\", \"rate\": 220}
\`\`\`

Without config, curby picks the best available voice automatically. Premium voices (Ava, Zoe, Allison) sound vastly more natural than basic Samantha — installable for free in ~2 min via System Settings → Accessibility → Spoken Content → System Voice → Manage Voices.

Closes #16.

## Test plan

- [x] 6 new pytests cover preference walk, override behavior, missing-say fallback, corrupt-config tolerance.
- [x] Full suite: 86 passed.
- [ ] **Manual**: with no Premium voice installed, expect startup hint + Samantha voice. Install Ava (Premium), restart curby, expect \`[voice] using Ava (Premium)\` line and noticeably better speech quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)