### PR TITLE
fix: feather back to companion mode

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -72,9 +72,10 @@ class CurbyApp:
         from src.answer_note import AnswerNote
         self._answer_note = AnswerNote()
 
-        # Hide the macOS system cursor so the ghost feather IS the cursor —
-        # no double-cursor visual conflict.
-        self._cursor_hider = SystemCursorHider()
+        # System cursor stays visible — the feather is a companion next to
+        # it, not a replacement. (Tried single-cursor mode but the feather's
+        # bobbing motion was unusable for actual pointing.)
+        self._cursor_hider = SystemCursorHider()  # kept for future use; not started
 
         self._cx = 0
         self._cy = 0
@@ -322,11 +323,7 @@ class CurbyApp:
         self._answer_note.show_initial()
         make_always_visible(self._answer_note)
 
-        # Hide the system cursor — ghost feather takes over.
-        if self._cursor_hider.start():
-            print("[cursor] system cursor hidden — ghost feather is the cursor")
-        else:
-            print("[cursor] could not hide system cursor (PyObjC/Quartz missing?)")
+        # (system cursor stays visible; feather is a companion)
 
         self._cursor.start()
         self._ptt.start()

--- a/src/ghost_cursor.py
+++ b/src/ghost_cursor.py
@@ -62,10 +62,11 @@ STATE_PRIMARY = {
 }
 
 SIZE = 120
-# Zero offset so the feather sits exactly on the real mouse position —
-# the system cursor is hidden, so this IS the cursor.
-FOLLOW_OFFSET_X = 0
-FOLLOW_OFFSET_Y = 0
+# Feather sits NEXT to the real cursor (cursor stays visible). Tried
+# zero-offset single-cursor mode briefly — the bobbing motion made it
+# unusable as a primary cursor, so we're back to companion mode.
+FOLLOW_OFFSET_X = 30
+FOLLOW_OFFSET_Y = 26
 SPRING = 0.14
 
 BOB_Y_AMP = 9.0


### PR DESCRIPTION
## Summary

#26 hid the system cursor and put the feather on the mouse position. In practice the feather's bobbing motion made it unusable for actual pointing. Revert to companion mode: system cursor visible, feather sits next to it like before.

All other #26 improvements preserved: new feather silhouette, soft aura, no rings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)