### PR TITLE
fix: decouple feather from cursor (fixes input lag)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -104,7 +104,11 @@ class CurbyApp:
         })
 
         # Wiring
-        self._bridge.cursor_moved.connect(self._voice.follow)
+        # NOTE: the feather is DECOUPLED from the system cursor — it lives at
+        # a fixed position next to the answer note. Per-frame move() calls
+        # following the cursor caused real input lag on macOS (window-level
+        # moves serialize with cursor input). The state animation still runs
+        # but the widget stays put.
         self._bridge.cursor_moved.connect(self._tasks.check_hover)
         self._bridge.ptt_toggled.connect(self._on_ptt_toggled)
         self._bridge.audio_level.connect(self._voice.set_level)
@@ -135,7 +139,6 @@ class CurbyApp:
             self._record_target = target
 
         self._voice.set_state("listening")
-        self._voice.follow(self._cx, self._cy)
 
         def _run():
             from src.voice_io import record_until_stop
@@ -308,22 +311,32 @@ class CurbyApp:
         self._qt.quit()
 
     def run(self):
-        # Place the indicator at the current cursor before showing it.
         from PyQt6.QtGui import QCursor
+        from PyQt6.QtWidgets import QApplication
         pos = QCursor.pos()
         self._cx, self._cy = pos.x(), pos.y()
-        self._voice.set_state("idle")
-        self._voice.follow(self._cx, self._cy)
-        self._voice.show()
-        self._voice.raise_()
-        make_always_visible(self._voice)
 
-        # Show the answer note top-right so the user knows it's there
-        # before the first quick-ask.
+        # Show the answer note top-right.
         self._answer_note.show_initial()
         make_always_visible(self._answer_note)
 
-        # (system cursor stays visible; feather is a companion)
+        # Pin the feather to a FIXED position next to the answer note.
+        # Decoupled from the cursor entirely — see #29. The feather is a
+        # state indicator paired with the answer note, not a cursor companion.
+        self._voice.set_state("idle")
+        screen = QApplication.primaryScreen()
+        if screen is not None:
+            geom = screen.availableGeometry()
+            # Just below the answer note's top-right anchor: 18px from the
+            # right edge, and beneath the note's visible footprint so the
+            # two read as a paired widget cluster.
+            note_h = self._answer_note.height()
+            x = geom.right() - 18 - 120          # GhostCursor SIZE = 120
+            y = geom.top() + 18 + note_h + 8
+            self._voice.pin_at(x, y)
+        self._voice.show()
+        self._voice.raise_()
+        make_always_visible(self._voice)
 
         self._cursor.start()
         self._ptt.start()

--- a/src/ghost_cursor.py
+++ b/src/ghost_cursor.py
@@ -107,6 +107,11 @@ class GhostCursor(QWidget):
         self._t0 = time.time()
         self._mode = self.MODE_FOLLOW
         self._state = "idle"
+        # When pinned, the tick loop skips the move() call — the widget stays
+        # at whatever position the host placed it via pin_at(). Used by curby
+        # to keep the feather as a fixed state indicator next to the answer
+        # note rather than a cursor companion (which caused input lag).
+        self._pinned = False
 
         self._real_user_x = 0.0
         self._real_user_y = 0.0
@@ -152,6 +157,13 @@ class GhostCursor(QWidget):
         GhostCursor's listening visual is driven by its own animation, not
         the raw level. Kept as a no-op so app.py wiring doesn't crash."""
         pass
+
+    def pin_at(self, x: int, y: int):
+        """Park the widget at a fixed top-left position and stop tracking
+        the cursor. The animation tick keeps running for paint updates;
+        only the per-frame move() is suppressed. Idempotent."""
+        self._pinned = True
+        self.move(int(x), int(y))
 
     def show_at(self, x: int, y: int):
         self._mode_change_t = time.time()
@@ -230,7 +242,7 @@ class GhostCursor(QWidget):
 
     def _tick(self):
         now = time.time()
-        if self._mode == self.MODE_FOLLOW:
+        if self._mode == self.MODE_FOLLOW and not self._pinned:
             self._smoothed_x += (self._target_x - self._smoothed_x) * SPRING
             self._smoothed_y += (self._target_y - self._smoothed_y) * SPRING
             elapsed = now - self._t0


### PR DESCRIPTION
User reported cursor lag and click misses with curby running. Root cause: per-frame window-move() calls following the cursor serialize with cursor input on macOS. Fix: pin the feather at a fixed position next to the AnswerNote and suppress the tick loop's move() calls. State animation keeps running. 87 tests pass.