### PR TITLE
feat: pluggable quick-ask backends (claude_cli + api_key + custom)

### DIFF
--- a/src/quick_ask.py
+++ b/src/quick_ask.py
@@ -83,57 +83,52 @@ def _clear_session() -> None:
 
 
 def run_quick_ask(prompt: str, *, worker=None, timeout: float = 30.0,
-                  claude_cli: str | None = None, model: str = "haiku") -> tuple[str, int, bool]:
-    """Ask the persistent claude worker a question. Returns (reply, latency_ms, was_followup).
+                  claude_cli: str | None = None, model: str = "haiku",
+                  system_addendum: str = "") -> tuple[str, int, bool]:
+    """Run a quick-ask through the configured backend. Returns (reply, latency_ms, was_followup).
 
-    The follow-up flag here means: was this question asked within the prior
-    session's window (i.e. the model has prior-turn context). With a
-    persistent worker the model already retains turn history within its
-    session, so "follow-up" is purely informational for logging.
+    Backend selection: reads `backend` from ~/.curby/config.json (default
+    "claude_cli"). Set to "api_key" + provide ANTHROPIC_API_KEY for sub-2 s
+    round-trips. Set to an absolute path to a .py file to use a custom
+    backend.
 
-    If no worker is passed (legacy / test path), spawns a one-shot
-    subprocess — slow but works.
+    `system_addendum` is appended to the base system prompt — used for
+    voice-set style preferences ("be shorter", etc.).
+
+    The `worker` arg is kept for API compat with the legacy persistent-worker
+    path; currently ignored (worker disabled — see #20).
     """
     now = _now()
     sess = _load_session()
     last = sess.get("last_used", 0.0)
     is_followup = (now - last) <= FOLLOWUP_WINDOW_SECONDS and bool(sess.get("session_id"))
 
-    if worker is not None:
-        try:
-            reply, latency_ms = worker.ask(prompt, timeout=timeout)
-        except RuntimeError:
-            # Worker died — try a one-shot fallback so the user still gets an answer.
-            reply, latency_ms = _one_shot(prompt, timeout=timeout,
-                                          claude_cli=claude_cli, model=model)
-        _save_session(sess.get("session_id", "worker"), _now())
-        return reply, latency_ms, is_followup
+    full_system = _SYSTEM if not system_addendum else f"{_SYSTEM}\n\n{system_addendum}"
+    backend_name = _resolve_backend_name()
+    from src.quick_ask_backends import load_backend
+    try:
+        ask_fn = load_backend(backend_name)
+        reply, latency_ms = ask_fn(prompt, full_system, model)
+    except Exception as e:
+        # Any backend failure falls back to claude_cli so the user always
+        # gets an answer (even if slow). Goes through load_backend so the
+        # fallback is mockable in tests.
+        if backend_name == "claude_cli":
+            raise
+        print(f"[quick-ask] backend {backend_name!r} failed: {e} — falling back to claude_cli", flush=True)
+        cli_ask = load_backend("claude_cli")
+        reply, latency_ms = cli_ask(prompt, full_system, model)
 
-    # No worker → one-shot path (legacy / tests).
-    reply, latency_ms = _one_shot(prompt, timeout=timeout,
-                                  claude_cli=claude_cli, model=model)
-    _save_session("oneshot", _now())
+    _save_session(backend_name, _now())
     return reply, latency_ms, is_followup
 
 
-def _one_shot(prompt: str, *, timeout: float, claude_cli: str | None, model: str) -> tuple[str, int]:
-    cli = claude_cli or _CLAUDE
-    wrapped = f"{_SYSTEM}\n\nQuestion: {prompt}"
-    cmd = [cli, "-p", "--model", model, wrapped]
-    started = time.monotonic()
+def _resolve_backend_name() -> str:
+    cfg_path = Path(os.path.expanduser("~/.curby/config.json"))
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-    except subprocess.TimeoutExpired:
-        raise RuntimeError(f"claude timed out after {timeout}s")
-    except FileNotFoundError:
-        raise RuntimeError(f"claude CLI not found at {cli!r}")
-    latency_ms = int((time.monotonic() - started) * 1000)
-    if result.returncode != 0:
-        raise RuntimeError(f"claude exited {result.returncode}: {(result.stderr or '').strip()[:200]}")
-    reply = (result.stdout or "").strip()
-    if not reply:
-        raise RuntimeError("claude returned no output")
-    return reply, latency_ms
+        return json.loads(cfg_path.read_text()).get("backend", "claude_cli")
+    except Exception:
+        return "claude_cli"
 
 
 def speak_reply(text: str) -> None:

--- a/src/quick_ask_backends/__init__.py
+++ b/src/quick_ask_backends/__init__.py
@@ -1,0 +1,57 @@
+"""Pluggable backends for quick-ask.
+
+Each backend exposes a single function:
+
+    ask(prompt: str, system: str, model: str = "haiku") -> tuple[str, int]
+
+…returning (reply_text, latency_ms). Raises RuntimeError on failure.
+
+Backends ship with curby:
+- "claude_cli" — shells out to `claude -p`. Works on Max plan with no setup
+  but pays ~5-6 s of CLI bootstrap per call.
+- "api_key"   — direct HTTPS to api.anthropic.com via the official anthropic
+  SDK. Requires ANTHROPIC_API_KEY in env or in ~/.curby/config.json.
+  Sub-2 s round-trips on Haiku.
+
+Users can also point `backend` in ~/.curby/config.json at a filesystem path
+to load a custom backend module. The module must define an `ask` function
+with the same signature. This keeps the public package free of any custom
+auth strategies — they live in user-controlled files outside the repo.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from collections.abc import Callable
+
+BackendFn = Callable[..., tuple[str, int]]
+
+
+def load_backend(name_or_path: str) -> BackendFn:
+    """Resolve a backend identifier to a callable `ask` function.
+
+    Accepts:
+    - "claude_cli" / "api_key" — built-in backends
+    - any absolute filesystem path to a .py file defining `ask(...)` —
+      loaded as a user module at runtime
+    """
+    if name_or_path == "claude_cli":
+        from src.quick_ask_backends.claude_cli import ask
+        return ask
+    if name_or_path == "api_key":
+        from src.quick_ask_backends.api_key import ask
+        return ask
+    # Treat as a filesystem path.
+    if not os.path.isabs(name_or_path) or not os.path.isfile(name_or_path):
+        raise ValueError(
+            f"Unknown backend {name_or_path!r}: not a built-in and not a "
+            f"path to a .py file. Built-ins: claude_cli, api_key."
+        )
+    spec = importlib.util.spec_from_file_location("curby_user_backend", name_or_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load backend at {name_or_path!r}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    if not hasattr(mod, "ask"):
+        raise RuntimeError(f"backend at {name_or_path!r} must define `ask(prompt, system, model)`")
+    return mod.ask

--- a/src/quick_ask_backends/api_key.py
+++ b/src/quick_ask_backends/api_key.py
@@ -1,0 +1,64 @@
+"""api_key backend — direct HTTPS to api.anthropic.com via the official
+anthropic SDK. Sub-2 s round-trips on Haiku.
+
+Requires an API key in one of:
+- `ANTHROPIC_API_KEY` env var
+- `api_key` field in ~/.curby/config.json
+
+This is the recommended fast-path for curby: cheap (Haiku is ~$1-3/month
+at typical voice-Q&A volumes) and clean (no TOS grey areas, no future
+breakage risk).
+"""
+import json
+import os
+import time
+from pathlib import Path
+
+
+_MODEL_MAP = {
+    "haiku":  "claude-haiku-4-5",
+    "sonnet": "claude-sonnet-4-6",
+    "opus":   "claude-opus-4-7",
+}
+
+
+def _resolve_api_key() -> str | None:
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return os.environ["ANTHROPIC_API_KEY"]
+    cfg_path = Path(os.path.expanduser("~/.curby/config.json"))
+    try:
+        return json.loads(cfg_path.read_text()).get("api_key")
+    except Exception:
+        return None
+
+
+def ask(prompt: str, system: str, model: str = "haiku") -> tuple[str, int]:
+    key = _resolve_api_key()
+    if not key:
+        raise RuntimeError(
+            "api_key backend selected but no ANTHROPIC_API_KEY found in env or "
+            "in ~/.curby/config.json (key: 'api_key')."
+        )
+    try:
+        import anthropic
+    except ImportError:
+        raise RuntimeError("anthropic SDK not installed (pip install anthropic)")
+
+    model_id = _MODEL_MAP.get(model, model)
+    client = anthropic.Anthropic(api_key=key)
+    started = time.monotonic()
+    msg = client.messages.create(
+        model=model_id,
+        max_tokens=200,
+        system=system,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    latency_ms = int((time.monotonic() - started) * 1000)
+    text = ""
+    for block in msg.content:
+        if getattr(block, "type", None) == "text":
+            text += getattr(block, "text", "")
+    text = text.strip()
+    if not text:
+        raise RuntimeError("anthropic API returned no text")
+    return text, latency_ms

--- a/src/quick_ask_backends/claude_cli.py
+++ b/src/quick_ask_backends/claude_cli.py
@@ -1,0 +1,28 @@
+"""claude_cli backend — shells out to `claude -p`. Works on Max plan with
+no extra setup; pays ~5-6 s of CLI bootstrap per call."""
+import os
+import shutil
+import subprocess
+import time
+
+_CLAUDE = os.environ.get("CLAUDE_CLI") or shutil.which("claude") or "claude"
+
+
+def ask(prompt: str, system: str, model: str = "haiku", *, timeout: float = 30.0) -> tuple[str, int]:
+    wrapped = f"{system}\n\nQuestion: {prompt}"
+    cmd = [_CLAUDE, "-p", "--model", model, wrapped]
+    started = time.monotonic()
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"claude timed out after {timeout}s")
+    except FileNotFoundError:
+        raise RuntimeError(f"claude CLI not found at {_CLAUDE!r}")
+    latency_ms = int((time.monotonic() - started) * 1000)
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()[:200]
+        raise RuntimeError(f"claude exited {result.returncode}: {stderr}")
+    reply = (result.stdout or "").strip()
+    if not reply:
+        raise RuntimeError("claude returned no output")
+    return reply, latency_ms

--- a/tests/test_quick_ask.py
+++ b/tests/test_quick_ask.py
@@ -1,8 +1,7 @@
-"""Headless coverage of the quick-ask module — mocks the `claude` subprocess
-and a temp log path so we never hit the real CLI or the user's home dir."""
+"""Coverage for quick_ask — mocks the backend dispatch so we never hit the
+real `claude` CLI or the real Anthropic API."""
 import json
 import pathlib
-import subprocess
 import sys
 import time
 
@@ -11,120 +10,104 @@ import pytest
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 
 from src import quick_ask
+from src import quick_ask_backends
 
 
 @pytest.fixture(autouse=True)
-def _isolate_session(tmp_path, monkeypatch):
+def _isolate_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(quick_ask, "SESSION_PATH", tmp_path / "session.json")
+    # Point ~/.curby/config.json at tmp so backend resolution defaults
+    # cleanly without picking up the real user config.
     monkeypatch.setenv("HOME", str(tmp_path))
     yield
 
 
-# ── One-shot fallback path (no worker) ─────────────────────────────────────
+# ── Backend dispatch ──────────────────────────────────────────────────────
 
-def test_one_shot_returns_reply_latency_and_followup_flag(monkeypatch):
-    captured = {}
-    def fake_run(cmd, capture_output, text, timeout):
-        captured["cmd"] = cmd
-        return subprocess.CompletedProcess(cmd, 0, stdout="hello world.\n", stderr="")
-    monkeypatch.setattr(quick_ask.subprocess, "run", fake_run)
-
-    reply, latency_ms, was_followup = quick_ask.run_quick_ask("hi", claude_cli="/usr/bin/claude")
-    assert reply == "hello world."
-    assert latency_ms >= 0
-    assert was_followup is False
-    assert "--model" in captured["cmd"] and "haiku" in captured["cmd"]
-
-
-def test_one_shot_raises_on_nonzero_exit(monkeypatch):
-    def fake_run(cmd, capture_output, text, timeout):
-        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="boom")
-    monkeypatch.setattr(quick_ask.subprocess, "run", fake_run)
-    with pytest.raises(RuntimeError, match="claude exited 1"):
-        quick_ask.run_quick_ask("hi", claude_cli="/usr/bin/claude")
-
-
-def test_one_shot_raises_on_empty_output(monkeypatch):
-    def fake_run(cmd, capture_output, text, timeout):
-        return subprocess.CompletedProcess(cmd, 0, stdout="   \n", stderr="")
-    monkeypatch.setattr(quick_ask.subprocess, "run", fake_run)
-    with pytest.raises(RuntimeError, match="no output"):
-        quick_ask.run_quick_ask("hi", claude_cli="/usr/bin/claude")
-
-
-def test_one_shot_raises_on_timeout(monkeypatch):
-    def fake_run(cmd, capture_output, text, timeout):
-        raise subprocess.TimeoutExpired(cmd, timeout)
-    monkeypatch.setattr(quick_ask.subprocess, "run", fake_run)
-    with pytest.raises(RuntimeError, match="timed out"):
-        quick_ask.run_quick_ask("hi", claude_cli="/usr/bin/claude", timeout=1.0)
-
-
-def test_one_shot_raises_when_cli_missing(monkeypatch):
-    def fake_run(cmd, capture_output, text, timeout):
-        raise FileNotFoundError(cmd[0])
-    monkeypatch.setattr(quick_ask.subprocess, "run", fake_run)
-    with pytest.raises(RuntimeError, match="claude CLI not found"):
-        quick_ask.run_quick_ask("hi", claude_cli="/nope/claude")
-
-
-# ── Worker path ────────────────────────────────────────────────────────────
-
-class _FakeWorker:
-    """Stand-in for ClaudeWorker used in tests."""
-    def __init__(self, replies=None, errors=None):
-        self.replies = replies or ["worker reply"]
-        self.errors = errors or []
-        self.calls = []
-
-    def ask(self, text, *, timeout=30.0):
-        self.calls.append(text)
-        if self.errors:
-            err = self.errors.pop(0)
+def _fake_backend(*replies, errors=()):
+    """Returns an ask() function suitable for monkeypatching load_backend."""
+    state = {"i": 0, "calls": [], "errors": list(errors)}
+    def ask(prompt, system, model="haiku"):
+        state["calls"].append((prompt, system, model))
+        if state["errors"]:
+            err = state["errors"].pop(0)
             if err:
                 raise RuntimeError(err)
-        return self.replies.pop(0), 1234
+        reply = replies[state["i"] % len(replies)]
+        state["i"] += 1
+        return reply, 1234
+    ask.state = state  # expose for test inspection
+    return ask
 
 
-def test_worker_path_uses_worker_not_subprocess(monkeypatch):
-    def fake_run(*a, **kw):
-        raise AssertionError("subprocess.run should NOT be called when a worker is provided")
-    monkeypatch.setattr(quick_ask.subprocess, "run", fake_run)
-
-    worker = _FakeWorker(replies=["from the worker."])
-    reply, latency_ms, was_followup = quick_ask.run_quick_ask("hi", worker=worker)
-    assert reply == "from the worker."
+def test_run_quick_ask_uses_default_backend(monkeypatch):
+    fake = _fake_backend("hello world")
+    monkeypatch.setattr(quick_ask_backends, "load_backend",
+                         lambda name: fake if name == "claude_cli" else (_ for _ in ()).throw(AssertionError("wrong backend")))
+    reply, latency_ms, was_followup = quick_ask.run_quick_ask("hi")
+    assert reply == "hello world"
     assert latency_ms == 1234
     assert was_followup is False
-    assert worker.calls == ["hi"]
+    assert len(fake.state["calls"]) == 1
 
 
-def test_worker_dead_falls_back_to_one_shot(monkeypatch):
-    def fake_run(cmd, capture_output, text, timeout):
-        return subprocess.CompletedProcess(cmd, 0, stdout="fallback ok.\n", stderr="")
-    monkeypatch.setattr(quick_ask.subprocess, "run", fake_run)
+def test_run_quick_ask_respects_configured_backend(monkeypatch, tmp_path):
+    (tmp_path / ".curby").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".curby" / "config.json").write_text('{"backend": "api_key"}')
+    fake = _fake_backend("api reply")
+    monkeypatch.setattr(quick_ask_backends, "load_backend",
+                         lambda name: fake if name == "api_key" else (_ for _ in ()).throw(AssertionError(f"got {name}")))
+    reply, _, _ = quick_ask.run_quick_ask("hi")
+    assert reply == "api reply"
 
-    worker = _FakeWorker(errors=["worker died"], replies=[])
-    reply, latency_ms, _ = quick_ask.run_quick_ask("hi", worker=worker, claude_cli="/usr/bin/claude")
-    assert reply == "fallback ok."
-    assert latency_ms >= 0
 
+def test_run_quick_ask_falls_back_to_claude_cli_on_failure(monkeypatch):
+    """If the configured backend raises, we fall back to claude_cli so the
+    user always gets an answer."""
+    fallback = _fake_backend("from fallback")
+    def loader(name):
+        if name == "api_key":
+            raise RuntimeError("backend boom")
+        if name == "claude_cli":
+            return fallback
+        raise AssertionError(f"unexpected backend {name}")
+    monkeypatch.setattr(quick_ask_backends, "load_backend", loader)
+    # Make config select api_key:
+    cfg = pathlib.Path(quick_ask.SESSION_PATH).parent / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(quick_ask, "_resolve_backend_name", lambda: "api_key")
+    reply, _, _ = quick_ask.run_quick_ask("hi")
+    assert reply == "from fallback"
+
+
+def test_run_quick_ask_passes_system_addendum(monkeypatch):
+    fake = _fake_backend("ok")
+    monkeypatch.setattr(quick_ask_backends, "load_backend", lambda _: fake)
+    quick_ask.run_quick_ask("hi", system_addendum="ALWAYS WHISPER")
+    _, system_used, _ = fake.state["calls"][0]
+    assert "ALWAYS WHISPER" in system_used
+    # Base system prompt should also be there.
+    assert "tutor" in system_used.lower()
+
+
+# ── Follow-up window ───────────────────────────────────────────────────────
 
 def test_followup_flag_flips_within_window(monkeypatch):
-    monkeypatch.setattr(quick_ask.subprocess, "run", lambda *a, **kw: (_ for _ in ()).throw(AssertionError("shouldn't run")))
-    worker = _FakeWorker(replies=["one", "two"])
-    _, _, first = quick_ask.run_quick_ask("first", worker=worker)
-    _, _, second = quick_ask.run_quick_ask("second", worker=worker)
+    fake = _fake_backend("one", "two")
+    monkeypatch.setattr(quick_ask_backends, "load_backend", lambda _: fake)
+    _, _, first = quick_ask.run_quick_ask("first")
+    _, _, second = quick_ask.run_quick_ask("second")
     assert first is False
     assert second is True
 
 
 def test_followup_flag_resets_after_window(monkeypatch):
     monkeypatch.setattr(quick_ask, "FOLLOWUP_WINDOW_SECONDS", 0.01)
-    worker = _FakeWorker(replies=["one", "two"])
-    _, _, first = quick_ask.run_quick_ask("first", worker=worker)
+    fake = _fake_backend("one", "two")
+    monkeypatch.setattr(quick_ask_backends, "load_backend", lambda _: fake)
+    _, _, first = quick_ask.run_quick_ask("first")
     time.sleep(0.05)
-    _, _, second = quick_ask.run_quick_ask("second", worker=worker)
+    _, _, second = quick_ask.run_quick_ask("second")
     assert first is False
     assert second is False
 
@@ -135,14 +118,12 @@ def test_log_quick_ask_writes_jsonl_entry(tmp_path):
     log = tmp_path / "quick-ask-log.jsonl"
     quick_ask.log_quick_ask("hello", "hi there", 142, log_path=log)
     quick_ask.log_quick_ask("again", "yep", 88, was_followup=True, log_path=log)
-
     lines = log.read_text().strip().splitlines()
     assert len(lines) == 2
     first = json.loads(lines[0])
     assert first["prompt_text"] == "hello"
     assert first["was_followup"] is False
-    second = json.loads(lines[1])
-    assert second["was_followup"] is True
+    assert json.loads(lines[1])["was_followup"] is True
 
 
 def test_log_quick_ask_swallows_write_errors(tmp_path, capsys):
@@ -151,3 +132,32 @@ def test_log_quick_ask_swallows_write_errors(tmp_path, capsys):
     bad = blocker / "nested" / "log.jsonl"
     quick_ask.log_quick_ask("p", "r", 1, log_path=bad)
     assert "log write failed" in capsys.readouterr().out
+
+
+# ── Backend loader ─────────────────────────────────────────────────────────
+
+def test_load_backend_builtin_claude_cli():
+    fn = quick_ask_backends.load_backend("claude_cli")
+    assert callable(fn)
+
+
+def test_load_backend_builtin_api_key():
+    fn = quick_ask_backends.load_backend("api_key")
+    assert callable(fn)
+
+
+def test_load_backend_custom_file(tmp_path):
+    plugin = tmp_path / "custom.py"
+    plugin.write_text(
+        "def ask(prompt, system, model='haiku'):\n"
+        "    return f'custom:{prompt}', 99\n"
+    )
+    fn = quick_ask_backends.load_backend(str(plugin))
+    reply, latency = fn("hello", "sys")
+    assert reply == "custom:hello"
+    assert latency == 99
+
+
+def test_load_backend_rejects_unknown():
+    with pytest.raises(ValueError, match="Unknown backend"):
+        quick_ask_backends.load_backend("nonsense_backend_name")


### PR DESCRIPTION
Pluggable backend dispatcher for quick-ask. Built-ins: claude_cli (default, ~7s) and api_key (~1-2s, needs ANTHROPIC_API_KEY). Custom backends loadable from any .py file the user configures. Falls back to claude_cli on any backend failure. 88 tests green.