### PR TITLE
feat: visible × icon + feather/note collapse sync + pidfile

### DIFF
--- a/src/answer_note.py
+++ b/src/answer_note.py
@@ -15,7 +15,7 @@ Pattern mirrors claude-meter/src/claude_meter/window.py:
 - mousePress→Move→Release with a small px threshold to distinguish
   click (toggle collapse) from drag (move the widget)
 """
-from PyQt6.QtCore import Qt, QPoint, QRectF, QTimer
+from PyQt6.QtCore import Qt, QPoint, QRectF, QTimer, pyqtSignal
 from PyQt6.QtGui import QPainter, QColor, QPen, QPainterPath, QFont, QFontMetrics
 from PyQt6.QtWidgets import QWidget, QApplication
 
@@ -31,6 +31,10 @@ PANEL_RADIUS         = 14
 DOT_SIZE             = 22
 EDGE_MARGIN          = 18
 DRAG_THRESHOLD_PX    = 4
+# Collapse icon in the top-right of the panel. Click inside this rect
+# collapses the panel; clicks anywhere else are passthrough / drag.
+COLLAPSE_BTN_SIZE    = 18
+COLLAPSE_BTN_MARGIN  = 10
 
 # Palette — soft electric blue accent on a deep matte background.
 BG                   = QColor(14,  16,  26, 246)
@@ -44,6 +48,11 @@ LABEL                = QColor(96, 165, 250, 200)
 
 class AnswerNote(QWidget):
     """Floating panel showing the latest quick-ask reply."""
+
+    # Emitted whenever the panel's collapsed state changes. Hosts can wire
+    # this to hide/show the companion feather so the whole curby cluster
+    # collapses as one unit.
+    collapse_changed = pyqtSignal(bool)   # True if now collapsed
 
     def __init__(self):
         super().__init__()
@@ -147,6 +156,16 @@ class AnswerNote(QWidget):
         if not keep_position:
             self.move(was_topleft)
         self.update()
+        self.collapse_changed.emit(collapsed)
+
+    def _collapse_btn_rect(self) -> QRectF:
+        """Hit-rect for the top-right collapse icon (panel mode only)."""
+        return QRectF(
+            self.width() - COLLAPSE_BTN_MARGIN - COLLAPSE_BTN_SIZE,
+            COLLAPSE_BTN_MARGIN,
+            COLLAPSE_BTN_SIZE,
+            COLLAPSE_BTN_SIZE,
+        )
 
     # ── Hover-driven click-through toggle ────────────────────────────────────
 
@@ -166,6 +185,17 @@ class AnswerNote(QWidget):
 
     def mousePressEvent(self, event):  # noqa: N802
         if event.button() != Qt.MouseButton.LeftButton:
+            return
+        pos = event.position().toPoint()
+        # Collapsed dot: click anywhere on the dot expands it back.
+        if self._collapsed:
+            self._set_collapsed(False, keep_position=True)
+            event.accept()
+            return
+        # Expanded panel: only the X icon collapses; everything else is drag.
+        if self._collapse_btn_rect().contains(pos):
+            self._set_collapsed(True, keep_position=True)
+            event.accept()
             return
         self._drag_origin = event.globalPosition().toPoint() - self.frameGeometry().topLeft()
         self._drag_moved = False
@@ -187,12 +217,8 @@ class AnswerNote(QWidget):
     def mouseReleaseEvent(self, event):  # noqa: N802
         if event.button() != Qt.MouseButton.LeftButton or self._drag_origin is None:
             return
-        was_dragged = self._drag_moved
         self._drag_origin = None
         self._drag_moved = False
-        if not was_dragged:
-            # Treat as a click → toggle collapse.
-            self._set_collapsed(not self._collapsed, keep_position=True)
         event.accept()
 
     # ── Paint ──────────────────────────────────────────────────────────────────
@@ -237,11 +263,32 @@ class AnswerNote(QWidget):
         label_text = "CURBY"
         if self._latency_ms is not None:
             label_text += f"   ·   {self._latency_ms} ms"
+        # Leave room for the collapse button on the right side.
+        header_w = int(self.width() - 2 * PANEL_PADDING - COLLAPSE_BTN_SIZE - 8)
         p.drawText(
             int(PANEL_PADDING), int(PANEL_PADDING),
-            int(self.width() - 2 * PANEL_PADDING), 20,
+            header_w, 20,
             int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop),
             label_text,
+        )
+
+        # Collapse "×" icon, top-right. Subtle by default; the rect is a
+        # generous click target even though the glyph is small.
+        btn = self._collapse_btn_rect()
+        # Tinted circle background so the icon reads as a button.
+        p.setPen(Qt.PenStyle.NoPen)
+        p.setBrush(QColor(255, 255, 255, 22))
+        p.drawEllipse(btn)
+        # The × itself
+        p.setPen(QPen(QColor(232, 234, 245, 200), 1.4))
+        inset = 5
+        p.drawLine(
+            int(btn.left() + inset), int(btn.top() + inset),
+            int(btn.right() - inset), int(btn.bottom() - inset),
+        )
+        p.drawLine(
+            int(btn.right() - inset), int(btn.top() + inset),
+            int(btn.left() + inset), int(btn.bottom() - inset),
         )
 
         # Body text.

--- a/src/app.py
+++ b/src/app.py
@@ -121,6 +121,21 @@ class CurbyApp:
         self._bridge.quit_hotkey_fired.connect(self._quit)
         self._bridge.voice_state_change.connect(self._voice.set_state)
         self._bridge.answer_ready.connect(self._answer_note.set_reply)
+        # Feather visibility tracks the answer-note's collapse state — the
+        # two read as one paired cluster.
+        self._answer_note.collapse_changed.connect(self._on_note_collapse_changed)
+
+    # ── Collapse coupling ─────────────────────────────────────────────────────
+
+    def _on_note_collapse_changed(self, collapsed: bool):
+        """When the answer note collapses to a dot, hide the feather too,
+        so the whole curby cluster reads as one collapsed unit. Expanding
+        the note brings the feather back."""
+        if collapsed:
+            self._voice.hide()
+        else:
+            self._voice.show()
+            self._voice.raise_()
 
     # ── Cursor follow ─────────────────────────────────────────────────────────
 
@@ -333,13 +348,36 @@ class CurbyApp:
         if self._claude_worker is not None:
             try: self._claude_worker.stop()
             except Exception: pass
+        # Explicitly close all our overlay widgets so nothing lingers if
+        # the Qt event loop is slow to tear down.
+        for w in (getattr(self, "_voice", None),
+                  getattr(self, "_answer_note", None),
+                  getattr(self, "_text_popup", None)):
+            try:
+                if w is not None:
+                    w.hide()
+                    w.close()
+            except Exception: pass
         self._tasks.shutdown()
         self._cursor.stop()
+        try:
+            from src import pidfile
+            pidfile.clear()
+        except Exception: pass
         self._qt.quit()
 
     def run(self):
         from PyQt6.QtGui import QCursor
         from PyQt6.QtWidgets import QApplication
+        from src import pidfile
+
+        # Kill any leftover curby from a previous run (e.g. force-killed,
+        # so its overlays never cleaned up). Then claim the pidfile.
+        killed = pidfile.kill_previous()
+        if killed:
+            print(f"[pidfile] killed stale curby pid {killed}", flush=True)
+        pidfile.write_self()
+
         pos = QCursor.pos()
         self._cx, self._cy = pos.x(), pos.y()
 

--- a/src/pidfile.py
+++ b/src/pidfile.py
@@ -1,0 +1,80 @@
+"""Pidfile management — ensures only one curby instance is running.
+
+On startup, if ~/.curby/curby.pid exists and points at a live process,
+kill it. Then write our own PID. On clean quit, remove the file.
+
+This prevents the "old curby still showing overlays" failure mode that
+happens when a previous run was force-killed (SIGKILL skips Qt's quit
+path, so any always-on-top windows can linger if the OS doesn't clean
+them up). Even when Qt does shut down cleanly, a stale instance from
+a different terminal can stack with a new one — pidfile catches that
+too.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import time
+from pathlib import Path
+
+PID_PATH = Path(os.path.expanduser("~/.curby/curby.pid"))
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        # signal 0 = no-op probe; raises if process doesn't exist
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+    except Exception:
+        return False
+
+
+def kill_previous() -> int:
+    """If a previous curby is running per the pidfile, kill it. Returns
+    the killed PID (or 0 if there was nothing to kill)."""
+    try:
+        raw = PID_PATH.read_text().strip()
+        prev_pid = int(raw)
+    except Exception:
+        return 0
+    if prev_pid == os.getpid() or not _pid_alive(prev_pid):
+        return 0
+    try:
+        os.kill(prev_pid, signal.SIGTERM)
+        # Give it ~1s to exit cleanly; force kill if still alive.
+        for _ in range(10):
+            time.sleep(0.1)
+            if not _pid_alive(prev_pid):
+                return prev_pid
+        os.kill(prev_pid, signal.SIGKILL)
+        return prev_pid
+    except Exception as e:
+        print(f"[pidfile] couldn't kill previous pid {prev_pid}: {e}")
+        return 0
+
+
+def write_self() -> None:
+    try:
+        PID_PATH.parent.mkdir(parents=True, exist_ok=True)
+        PID_PATH.write_text(str(os.getpid()))
+    except Exception as e:
+        print(f"[pidfile] write failed: {e}")
+
+
+def clear() -> None:
+    try:
+        if PID_PATH.exists():
+            # Only remove if it's still our PID (avoid clobbering a freshly
+            # written file from a concurrent start).
+            try:
+                raw = PID_PATH.read_text().strip()
+                if int(raw) == os.getpid():
+                    PID_PATH.unlink()
+            except Exception:
+                PID_PATH.unlink()
+    except Exception as e:
+        print(f"[pidfile] cleanup failed: {e}")


### PR DESCRIPTION
Three coupled fixes: visible × collapse button (replaces click-anywhere), feather hides+shows with the answer note as one paired cluster, and a pidfile that kills stale curby instances on startup to prevent lingering overlays. 98 tests pass.