### PR TITLE
feat: conversation history + interrupt-on-Ctrl+Space

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -90,6 +90,16 @@ class CurbyApp:
         # QUICK_ASK_TARGET sentinel = route to quick-ask flow.
         self._record_target: Task | str | None = None
 
+        # Conversation state for quick-ask follow-ups. Kept in-memory only —
+        # cleared after the FOLLOWUP_WINDOW expires, or when user says
+        # something like "reset" / "back to normal".
+        self._conv_history: list[dict] = []   # [{"role", "content"}, ...]
+        self._conv_last_turn_at: float = 0.0
+
+        # Active TTS subprocess (`say`). Tracked so Ctrl+Space mid-speech
+        # can kill it and immediately listen for the next question.
+        self._active_tts_proc = None  # subprocess.Popen | None
+
         # Hotkeys — toggle: tap chord to start, tap again to send.
         # Agent-spawn moved to Ctrl+Shift+Space; Ctrl+Space is now quick-ask (primary).
         from pynput import keyboard
@@ -243,9 +253,16 @@ class CurbyApp:
                 self._stop_recording()
             else:
                 print("[quick-ask] another recording in progress — ignoring")
-        else:
-            print("[quick-ask] toggle on — listening", flush=True)
-            self._start_recording(target=QUICK_ASK_TARGET)
+            return
+        # Not currently recording. If curby is mid-speech (TTS playing), the
+        # user wants to interrupt — kill the speech and start listening.
+        if self._active_tts_proc is not None:
+            print("[quick-ask] interrupting speech — listening", flush=True)
+            try: self._active_tts_proc.kill()
+            except Exception: pass
+            self._active_tts_proc = None
+        print("[quick-ask] toggle on — listening", flush=True)
+        self._start_recording(target=QUICK_ASK_TARGET)
 
     # ── Per-task amend ────────────────────────────────────────────────────────
 
@@ -285,15 +302,21 @@ class CurbyApp:
     def _run_quick_ask(self, prompt: str):
         """Run the quick-ask in a background thread so the Qt loop stays responsive.
 
-        The indicator state is driven via bridge signals (Qt-thread-safe):
-        thinking (already set by caller) → speaking (just before TTS) → idle.
+        Maintains conversation history in self._conv_history so multi-turn
+        questions ("but what about X?") work correctly — the model sees
+        prior turns. History is cleared if more than FOLLOWUP_WINDOW seconds
+        have passed since the last turn (per quick_ask.FOLLOWUP_WINDOW_SECONDS).
 
-        If the model returns a PREFERENCE_UPDATE: directive (style instruction
-        the user said via voice — see src/preferences.py), we capture it and
-        speak a short ack instead of speaking the directive itself.
+        Tracks the active TTS subprocess so Ctrl+Space mid-speech can kill
+        it for instant interrupt.
         """
         worker = self._claude_worker
         bridge = self._bridge
+        history = self._take_history_snapshot()
+
+        def _register_tts(proc):
+            self._active_tts_proc = proc
+
         def _work():
             from src.quick_ask import run_quick_ask, log_quick_ask, speak_reply
             from src import preferences
@@ -301,12 +324,13 @@ class CurbyApp:
             try:
                 reply, latency_ms, was_followup = run_quick_ask(
                     prompt, worker=worker, system_addendum=addendum,
+                    history=history,
                 )
             except Exception as e:
                 msg = f"quick-ask failed: {e}"
                 print(f"[quick-ask] {msg}", flush=True)
                 bridge.voice_state_change.emit("error")
-                try: speak_reply("sorry, something went wrong.")
+                try: speak_reply("sorry, something went wrong.", register_proc=_register_tts)
                 except Exception: pass
                 bridge.voice_state_change.emit("idle")
                 return
@@ -315,6 +339,9 @@ class CurbyApp:
             if is_pref:
                 if payload.strip().upper() == "RESET":
                     preferences.clear()
+                    # Also reset conversation history — "back to normal" should
+                    # be a full reset, not just style.
+                    self._conv_history = []
                     ack = "okay, back to normal."
                     print(f"[prefs] reset", flush=True)
                 else:
@@ -324,18 +351,44 @@ class CurbyApp:
                 log_quick_ask(prompt, f"[PREF] {payload}", latency_ms, was_followup=was_followup)
                 bridge.answer_ready.emit(f"⚙ preference: {payload}", latency_ms)
                 bridge.voice_state_change.emit("speaking")
-                speak_reply(ack)
+                speak_reply(ack, register_proc=_register_tts)
                 bridge.voice_state_change.emit("idle")
                 return
 
             tag = "follow-up" if was_followup else "new"
             print(f"[quick-ask] {tag} reply ({latency_ms} ms): {reply!r}", flush=True)
             log_quick_ask(prompt, reply, latency_ms, was_followup=was_followup)
+            # Record this turn into conversation history so future "but what
+            # about X" questions see the prior context.
+            self._record_turn(prompt, reply)
             bridge.answer_ready.emit(reply, latency_ms)
             bridge.voice_state_change.emit("speaking")
-            speak_reply(reply)  # blocks until TTS completes (subprocess wait)
+            speak_reply(reply, register_proc=_register_tts)
             bridge.voice_state_change.emit("idle")
         threading.Thread(target=_work, daemon=True).start()
+
+    # ── Conversation history ─────────────────────────────────────────────────
+
+    _MAX_HISTORY_TURNS = 8   # = 4 user + 4 assistant; keeps tokens bounded
+
+    def _take_history_snapshot(self) -> list[dict]:
+        """Return the live history if we're still within the follow-up
+        window; otherwise clear and return empty. Called at the start of
+        each quick-ask turn so each call gets a coherent snapshot."""
+        import time
+        from src.quick_ask import FOLLOWUP_WINDOW_SECONDS
+        if (time.time() - self._conv_last_turn_at) > FOLLOWUP_WINDOW_SECONDS:
+            self._conv_history = []
+        return list(self._conv_history)
+
+    def _record_turn(self, user_text: str, assistant_text: str) -> None:
+        import time
+        self._conv_history.append({"role": "user", "content": user_text})
+        self._conv_history.append({"role": "assistant", "content": assistant_text})
+        # Cap at the most recent N entries (FIFO).
+        if len(self._conv_history) > self._MAX_HISTORY_TURNS * 2:
+            self._conv_history = self._conv_history[-self._MAX_HISTORY_TURNS * 2:]
+        self._conv_last_turn_at = time.time()
 
     def _on_transcription_error(self, msg: str):
         target = self._record_target

--- a/src/quick_ask.py
+++ b/src/quick_ask.py
@@ -101,7 +101,8 @@ def _clear_session() -> None:
 
 def run_quick_ask(prompt: str, *, worker=None, timeout: float = 30.0,
                   claude_cli: str | None = None, model: str = "haiku",
-                  system_addendum: str = "") -> tuple[str, int, bool]:
+                  system_addendum: str = "",
+                  history: list[dict] | None = None) -> tuple[str, int, bool]:
     """Run a quick-ask through the configured backend. Returns (reply, latency_ms, was_followup).
 
     Backend selection: reads `backend` from ~/.curby/config.json (default
@@ -125,7 +126,7 @@ def run_quick_ask(prompt: str, *, worker=None, timeout: float = 30.0,
     from src.quick_ask_backends import load_backend
     try:
         ask_fn = load_backend(backend_name)
-        reply, latency_ms = ask_fn(prompt, full_system, model)
+        reply, latency_ms = ask_fn(prompt, full_system, model, history=history)
     except Exception as e:
         # Any backend failure falls back to claude_cli so the user always
         # gets an answer (even if slow). Goes through load_backend so the
@@ -134,7 +135,7 @@ def run_quick_ask(prompt: str, *, worker=None, timeout: float = 30.0,
             raise
         print(f"[quick-ask] backend {backend_name!r} failed: {e} — falling back to claude_cli", flush=True)
         cli_ask = load_backend("claude_cli")
-        reply, latency_ms = cli_ask(prompt, full_system, model)
+        reply, latency_ms = cli_ask(prompt, full_system, model, history=history)
 
     _save_session(backend_name, _now())
     return reply, latency_ms, is_followup
@@ -148,11 +149,13 @@ def _resolve_backend_name() -> str:
         return "claude_cli"
 
 
-def speak_reply(text: str) -> None:
-    """Speak the reply, preferring macOS `say` (reliable subprocess) over
-    pyttsx3 (which can deadlock when invoked from non-main threads on macOS).
+def speak_reply(text: str, *, register_proc=None) -> None:
+    """Speak the reply, preferring macOS `say`. Blocks until speech ends
+    OR the registered process is externally killed (which happens when
+    the user taps Ctrl+Space mid-speech to interrupt).
 
-    Falls back to voice_io.speak on non-macOS or if `say` is unavailable.
+    `register_proc` is an optional callback that receives the live Popen
+    handle so the caller (CurbyApp) can track + kill it on interrupt.
     """
     if platform.system() == "Darwin" and shutil.which("say"):
         try:
@@ -162,7 +165,18 @@ def speak_reply(text: str) -> None:
             if voice:
                 cmd += ["-v", voice]
             cmd.append(text)
-            subprocess.run(cmd, check=False, timeout=60)
+            proc = subprocess.Popen(cmd)
+            if register_proc is not None:
+                try: register_proc(proc)
+                except Exception: pass
+            try:
+                proc.wait(timeout=60)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            finally:
+                if register_proc is not None:
+                    try: register_proc(None)
+                    except Exception: pass
             return
         except Exception as e:
             print(f"[quick-ask] say failed, falling back to pyttsx3: {e}")

--- a/src/quick_ask_backends/__init__.py
+++ b/src/quick_ask_backends/__init__.py
@@ -2,9 +2,15 @@
 
 Each backend exposes a single function:
 
-    ask(prompt: str, system: str, model: str = "haiku") -> tuple[str, int]
+    ask(prompt: str, system: str, model: str = "haiku", *,
+        history: list[dict] | None = None) -> tuple[str, int]
 
 …returning (reply_text, latency_ms). Raises RuntimeError on failure.
+
+`history` is an optional conversation history — a list of
+{"role": "user"|"assistant", "content": str} entries from prior turns.
+Backends that support multi-turn (api_key, oauth) include it in the
+messages array; backends that don't (claude_cli one-shot) ignore it.
 
 Backends ship with curby:
 - "claude_cli" — shells out to `claude -p`. Works on Max plan with no setup

--- a/src/quick_ask_backends/api_key.py
+++ b/src/quick_ask_backends/api_key.py
@@ -32,7 +32,8 @@ def _resolve_api_key() -> str | None:
         return None
 
 
-def ask(prompt: str, system: str, model: str = "haiku") -> tuple[str, int]:
+def ask(prompt: str, system: str, model: str = "haiku", *,
+        history: list[dict] | None = None) -> tuple[str, int]:
     key = _resolve_api_key()
     if not key:
         raise RuntimeError(
@@ -46,12 +47,13 @@ def ask(prompt: str, system: str, model: str = "haiku") -> tuple[str, int]:
 
     model_id = _MODEL_MAP.get(model, model)
     client = anthropic.Anthropic(api_key=key)
+    messages = list(history or []) + [{"role": "user", "content": prompt}]
     started = time.monotonic()
     msg = client.messages.create(
         model=model_id,
         max_tokens=200,
         system=system,
-        messages=[{"role": "user", "content": prompt}],
+        messages=messages,
     )
     latency_ms = int((time.monotonic() - started) * 1000)
     text = ""

--- a/src/quick_ask_backends/claude_cli.py
+++ b/src/quick_ask_backends/claude_cli.py
@@ -8,7 +8,10 @@ import time
 _CLAUDE = os.environ.get("CLAUDE_CLI") or shutil.which("claude") or "claude"
 
 
-def ask(prompt: str, system: str, model: str = "haiku", *, timeout: float = 30.0) -> tuple[str, int]:
+def ask(prompt: str, system: str, model: str = "haiku", *,
+        history: list[dict] | None = None, timeout: float = 30.0) -> tuple[str, int]:
+    # `history` ignored — claude_cli is the slow one-shot fallback; users on
+    # this path don't need multi-turn yet. (--continue could be wired later.)
     wrapped = f"{system}\n\nQuestion: {prompt}"
     cmd = [_CLAUDE, "-p", "--model", model, wrapped]
     started = time.monotonic()

--- a/tests/test_quick_ask.py
+++ b/tests/test_quick_ask.py
@@ -27,8 +27,8 @@ def _isolate_paths(tmp_path, monkeypatch):
 def _fake_backend(*replies, errors=()):
     """Returns an ask() function suitable for monkeypatching load_backend."""
     state = {"i": 0, "calls": [], "errors": list(errors)}
-    def ask(prompt, system, model="haiku"):
-        state["calls"].append((prompt, system, model))
+    def ask(prompt, system, model="haiku", *, history=None):
+        state["calls"].append((prompt, system, model, list(history or [])))
         if state["errors"]:
             err = state["errors"].pop(0)
             if err:
@@ -84,10 +84,21 @@ def test_run_quick_ask_passes_system_addendum(monkeypatch):
     fake = _fake_backend("ok")
     monkeypatch.setattr(quick_ask_backends, "load_backend", lambda _: fake)
     quick_ask.run_quick_ask("hi", system_addendum="ALWAYS WHISPER")
-    _, system_used, _ = fake.state["calls"][0]
+    _, system_used, _, _ = fake.state["calls"][0]
     assert "ALWAYS WHISPER" in system_used
-    # Base system prompt should also be there.
     assert "tutor" in system_used.lower()
+
+
+def test_run_quick_ask_passes_history_to_backend(monkeypatch):
+    fake = _fake_backend("ok")
+    monkeypatch.setattr(quick_ask_backends, "load_backend", lambda _: fake)
+    hist = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first reply"},
+    ]
+    quick_ask.run_quick_ask("second", history=hist)
+    _, _, _, history_used = fake.state["calls"][0]
+    assert history_used == hist
 
 
 # ── Follow-up window ───────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-ups now actually pass prior turns to Claude (was previously context-free even when the 'followup' flag was true). Ctrl+Space mid-speech now kills the TTS and starts listening immediately. 99 tests pass.